### PR TITLE
Add support for WSLg

### DIFF
--- a/build-tarball.nix
+++ b/build-tarball.nix
@@ -27,7 +27,7 @@ let
     mkdir -m 1777 ./tmp
 
     # WSL requires a /bin/sh - only temporary, NixOS's activate will overwrite
-    ln -s ${pkgs.stdenv.shell} ./bin/sh
+    ln -s ${config.users.users.root.shell} ./bin/sh
 
     # WSL also requires a /bin/mount, otherwise the host fs isn't accessible
     ln -s /nix/var/nix/profiles/system/sw/bin/mount ./bin/mount
@@ -61,7 +61,6 @@ in
 
     storeContents = pkgs2storeContents [
       config.system.build.toplevel
-      pkgs.stdenv
       channelSources
       preparer
     ];

--- a/configuration.nix
+++ b/configuration.nix
@@ -48,17 +48,6 @@ in
   # Don't allow emergency mode, because we don't have a console.
   systemd.enableEmergencyMode = false;
 
-
-  # WSLg support
-  environment.variables = {
-    DISPLAY = ":0";
-    WAYLAND_DISPLAY = "wayland-0";
-
-    PULSE_SERVER = "${automountPath}/wslg/PulseServer";
-    XDG_RUNTIME_DIR = "${automountPath}/wslg/runtime-dir";
-    WSL_INTEROP = "/run/WSL/1_interop";
-  };
-
   environment.etc."wsl.conf".text = ''
     [automount]
     enabled=true
@@ -67,11 +56,11 @@ in
     options=metadata,uid=1000,gid=100
   '';
 
-  system.activationScripts.copy-launchers.text = ''
-    for x in applications icons; do
-      echo "Copying /usr/share/$x"
-      rm -rf /usr/share/$x
-      cp -r $systemConfig/sw/share/$x/. /usr/share/$x
-    done
-  '';
+  system.activationScripts = {
+    copy-launchers = stringAfter [] ''
+      for x in applications icons; do
+        echo "Copying /usr/share/$x"
+        ${pkgs.rsync}/bin/rsync -ar --delete $systemConfig/sw/share/$x/. /usr/share/$x
+      done
+    '';
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1617631617,
-        "narHash": "sha256-PARRCz55qN3gy07VJZIlFeOX420d0nGF0RzGI/9hVlw=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b2c27d1a81b0dc266270fa8aeecebbd1807fc610",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1618064689,
-        "narHash": "sha256-MGnHpM3bSd5JClA+1ad+jvcfNr0HrYoGmqCc2s7thkM=",
+        "lastModified": 1625876282,
+        "narHash": "sha256-z/Gv+11Uzdv3HcQCY+xGi1+iuc3rmCaPzxxDSMnuRAI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad7604ddbd9b299701fb5e15bc39cff80deffce2",
+        "rev": "068984c00e0d4e54b6684d98f6ac47c92dcb642e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1614513358,
-        "narHash": "sha256-LakhOx3S1dRjnh0b5Dg3mbZyH0ToC9I8Y2wKSkBaTzU=",
+        "lastModified": 1617631617,
+        "narHash": "sha256-PARRCz55qN3gy07VJZIlFeOX420d0nGF0RzGI/9hVlw=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5466c5bbece17adaab2d82fae80b46e807611bf3",
+        "rev": "b2c27d1a81b0dc266270fa8aeecebbd1807fc610",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1616237945,
-        "narHash": "sha256-rU+QAUxPG3BN16gBBeovz8eqITHhzewv+4o94iF57qY=",
+        "lastModified": 1618064689,
+        "narHash": "sha256-MGnHpM3bSd5JClA+1ad+jvcfNr0HrYoGmqCc2s7thkM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "66f4dc4fd1b47e9e06d0f1bd78faffa51f0cc59c",
+        "rev": "ad7604ddbd9b299701fb5e15bc39cff80deffce2",
         "type": "github"
       },
       "original": {

--- a/syschdemd.sh
+++ b/syschdemd.sh
@@ -40,4 +40,4 @@ if [[ $# -gt 0 ]]; then
 else
     cmd="$userShell"
 fi
-exec $sw/nsenter -t $(< /run/systemd.pid) -p -m -- $sw/machinectl -q --uid=@defaultUser@ shell .host /bin/sh -c "cd \"$PWD\"; exec $cmd"
+exec $sw/nsenter -t $(< /run/systemd.pid) -p -m -- $sw/machinectl -q --uid=@defaultUser@ shell .host /bin/sh --login -c "cd \"$PWD\"; exec $cmd"


### PR DESCRIPTION
This PR adds support for [WSLg](https://github.com/microsoft/wslg).
GUI Applications can be launched from a shell as well as from the start menu

I added an activation script, that copies the application launchers to `/usr/share/applications` so that the installed applications will appear in the windows start menu

`syschdemd.sh` was changed to start `/bin/sh` as a login shell because the environment variables aren't present otherwise