### PR TITLE
Yet another environment pass-through PR

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -13,6 +13,9 @@ in
   # WSL is closer to a container than anything else
   boot.isContainer = true;
 
+  # Include Windows %PATH% in Linux $PATH.
+  environment.extraInit = ''PATH="$PATH:$WSLPATH"'';
+
   environment.etc.hosts.enable = false;
   environment.etc."resolv.conf".enable = false;
 

--- a/syschdemd.sh
+++ b/syschdemd.sh
@@ -40,4 +40,10 @@ if [[ $# -gt 0 ]]; then
 else
     cmd="$userShell"
 fi
-exec $sw/nsenter -t $(< /run/systemd.pid) -p -m -- $sw/machinectl -q --uid=@defaultUser@ shell .host /bin/sh -c "cd \"$PWD\"; exec $cmd"
+
+# Pass external environment but filter variables specific to root user.
+exportCmd="$(export -p | $sw/grep -vE ' (HOME|LOGNAME|SHELL|USER)=')"
+
+exec $sw/nsenter -t $(< /run/systemd.pid) -p -m -- $sw/machinectl -q \
+	--uid=@defaultUser@ shell .host /bin/sh -c \
+	"cd \"$PWD\"; $exportCmd; exec $cmd"

--- a/syschdemd.sh
+++ b/syschdemd.sh
@@ -42,7 +42,7 @@ else
 fi
 
 # Pass external environment but filter variables specific to root user.
-exportCmd="$(export -p | $sw/grep -vE ' (HOME|LOGNAME|SHELL|USER)=')"
+exportCmd="$(export -p | $sw/grep -vE ' (HOME|LOGNAME|SHELL|USER)='); export WSLPATH=\"$PATH\""
 
 exec $sw/nsenter -t $(< /run/systemd.pid) -p -m -- $sw/machinectl -q \
 	--uid=@defaultUser@ shell .host /bin/sh -c \


### PR DESCRIPTION
- Compared to #39: I did not hard-code anything, so there won't be an ever-growing list of environment variables we need to manually pass through.
- Compared to #40: I did not switch to `systemd-run`, therefore systemd still starts user sessions. Avoids reintroducing issues like #18 and #29.
- Compared to #41: My patch is simpler and doesn't combine `machinectl` and `systemd-run` in confusing ways.

I also added the Windows %PATH% to the Linux $PATH, so running Windows exe's doesn't require specifying the full absolute file path.