### PR TITLE
Fix root shell (Fixes #51)

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -29,7 +29,12 @@ in
     extraGroups = [ "root" ];
   };
 
-  security.sudo.wheelNeedsPassword = false;
+  security.sudo = {
+    extraConfig = ''
+      Defaults env_keep+=INSIDE_NAMESPACE
+    '';
+    wheelNeedsPassword = false;
+  };
 
   # Disable systemd units that don't make sense on WSL
   systemd.services."serial-getty@ttyS0".enable = false;


### PR DESCRIPTION
When a root shell is started from within the systemd namespace, syschdemd.sh will try to enter the namespace again which causes the command to fail. This PR adds a new environment variable INSIDE_NAMESPACE that is used to detect this and start the requested command directly