### PR TITLE
Everything that changed in my fork of this repo

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+use_flake() {
+    watch_file flake.nix
+    watch_file flake.lock
+    eval "$(nix print-dev-env)"
+}
+
+use flake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,21 @@ jobs:
         run: |
           nix build '.#nixosConfigurations.mysystem.config.system.build.tarball'
 
-      - uses: actions/upload-artifact@v2
+      - name: Upload tarball
+        uses: actions/upload-artifact@v2
         with:
-          name: install.tar.gz
+          name: rootfs
           path: result/tarball/nixos-wsl-x86_64-linux.tar.gz
+
+      - name: Build installer
+        run: |
+          nix build '.#nixosConfigurations.mysystem.config.system.build.installer'
+
+      - name: Upload installer
+        uses: actions/upload-artifact@v2
+        with:
+          name: installer
+          path: result/tarball/nixos-wsl-installer.tar.gz
 
   release:
     if: startsWith(github.ref, 'refs/tags/')
@@ -43,7 +54,11 @@ jobs:
 
       - uses: actions/download-artifact@v2
         with:
-          name: install.tar.gz
+          name: rootfs
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: installer
 
       - name: Create Release
         id: create_release
@@ -59,7 +74,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} #
-          asset_name: install.tar.gz
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: nixos-wsl-x86_64-linux.tar.gz
           asset_path: result/tarball/nixos-wsl-x86_64-linux.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload installer as release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: nixos-wsl-installer.tar.gz
+          asset_path: result/tarball/nixos-wsl-installer.tar.gz
           asset_content_type: application/gzip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: install.tar.gz
-          path: result/tarball/nixos-system-x86_64-linux.tar.gz
+          path: result/tarball/*.tar.gz
 
   release:
     if: startsWith(github.ref, 'refs/tags/')
@@ -60,6 +60,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} #
-          asset_name: nixos-system-x86_64-linux.tar.gz
-          asset_path: nixos-system-x86_64-linux.tar.gz
+          asset_name: install.tar.gz
+          asset_path: result/tarball/*.tar.gz
           asset_content_type: application/gzip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: install.tar.gz
-          path: result/tarball/*.tar.gz
+          path: result/tarball/nixos-wsl-x86_64-linux.tar.gz
 
   release:
     if: startsWith(github.ref, 'refs/tags/')
@@ -61,5 +61,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} #
           asset_name: install.tar.gz
-          asset_path: result/tarball/*.tar.gz
+          asset_path: result/tarball/nixos-wsl-x86_64-linux.tar.gz
           asset_content_type: application/gzip

--- a/README.rst
+++ b/README.rst
@@ -15,10 +15,10 @@ First, `download the latest release's system tarball
 
 Then open up a Terminal, PowerShell or Command Prompt and run::
 
-   wsl --import NixOS .\NixOS\ nixos-system-x86_64-linux.tar.gz --version 2
+   wsl --import NixOS .\NixOS\ nixos-wsl-x86_64-linux.tar.gz --version 2
 
 This sets up a new WSL distribution ``NixOS`` that is installed under
-``.\NixOS``. ``nixos-system-x86_64-linux.tar.gz`` is the path to the file you
+``.\NixOS``. ``nixos-wsl-x86_64-linux.tar.gz`` is the path to the file you
 downloaded earlier. You might need to change this path or change to the download
 directory first.
 
@@ -72,10 +72,10 @@ Or, if you want to build with local changes, run inside your checkout::
 
 Without a flakes-enabled Nix, you can build a tarball using::
 
-   nix-build -A system -A config.system.build.tarball ./nixos.nix
+   nix-build -A nixosConfigurations.mysystem.config.system.build.tarball
 
 The resulting mini rootfs can then be found under
-``./result-2/tarball/nixos-system-x86_64-linux.tar.gz``.
+``./result/tarball/nixos-wsl-x86_64-linux.tar.gz``.
 
 
 License

--- a/build-tarball.nix
+++ b/build-tarball.nix
@@ -27,7 +27,7 @@ let
     mkdir -m 1777 ./tmp
 
     # WSL requires a /bin/sh - only temporary, NixOS's activate will overwrite
-    ln -s ${pkgs.stdenv.shell} ./bin/sh
+    ln -s ${config.users.users.root.shell} ./bin/sh
 
     # WSL also requires a /bin/mount, otherwise the host fs isn't accessible
     ln -s /nix/var/nix/profiles/system/sw/bin/mount ./bin/mount
@@ -61,7 +61,6 @@ in
 
     storeContents = pkgs2storeContents [
       config.system.build.toplevel
-      pkgs.stdenv
       channelSources
       preparer
     ];

--- a/configuration.nix
+++ b/configuration.nix
@@ -12,64 +12,18 @@ in
     "${modulesPath}/profiles/minimal.nix"
 
     build-tarball
+    wsl-distro
   ];
 
-  # WSL is closer to a container than anything else
-  boot.isContainer = true;
-
-  # Include Windows %PATH% in Linux $PATH.
-  environment.extraInit = ''PATH="$PATH:$WSLPATH"'';
-
-  environment.etc.hosts.enable = false;
-  environment.etc."resolv.conf".enable = false;
-
-  networking.dhcpcd.enable = false;
-
-  users.users.${defaultUser} = {
-    isNormalUser = true;
-    extraGroups = [ "wheel" ];
+  wsl = {
+    enable = true;
+    automountPath = "/mnt";
+    defaultUser = "nixos";
+    startMenuLaunchers = true;
   };
 
-  users.users.root = {
-    shell = "${syschdemd}/bin/syschdemd";
-    # Otherwise WSL fails to login as root with "initgroups failed 5"
-    extraGroups = [ "root" ];
-  };
-
-  security.sudo = {
-    extraConfig = ''
-      Defaults env_keep+=INSIDE_NAMESPACE
-    '';
-    wheelNeedsPassword = false;
-  };
-
-  # Disable systemd units that don't make sense on WSL
-  systemd.services."serial-getty@ttyS0".enable = false;
-  systemd.services."serial-getty@hvc0".enable = false;
-  systemd.services."getty@tty1".enable = false;
-  systemd.services."autovt@".enable = false;
-
-  systemd.services.firewall.enable = false;
-  systemd.services.systemd-resolved.enable = false;
-  systemd.services.systemd-udevd.enable = false;
-
-  # Don't allow emergency mode, because we don't have a console.
-  systemd.enableEmergencyMode = false;
-
-  environment.etc."wsl.conf".text = ''
-    [automount]
-    enabled=true
-    mountFsTab=true
-    root=${automountPath}/
-    options=metadata,uid=1000,gid=100
+  # Enable nix-flakes by default
+  nix.extraOptions = ''
+    experimental-features = nix-command flakes
   '';
-
-  system.activationScripts = {
-    copy-launchers = stringAfter [] ''
-      for x in applications icons; do
-        echo "Copying /usr/share/$x"
-        ${pkgs.rsync}/bin/rsync -ar --delete $systemConfig/sw/share/$x/. /usr/share/$x
-      done
-    '';
-  };
 }

--- a/configuration.nix
+++ b/configuration.nix
@@ -12,6 +12,7 @@ in
     "${modulesPath}/profiles/minimal.nix"
 
     build-tarball
+    docker-desktop
     wsl-distro
   ];
 
@@ -20,6 +21,9 @@ in
     automountPath = "/mnt";
     defaultUser = "nixos";
     startMenuLaunchers = true;
+
+    # Enable integration with Docker Desktop (needs to be installed)
+    # docker.enable = true;
   };
 
   # Enable nix-flakes by default

--- a/configuration.nix
+++ b/configuration.nix
@@ -5,10 +5,13 @@ let
   defaultUser = "nixos";
   automountPath = "/mnt";
   syschdemd = import ./syschdemd.nix { inherit lib pkgs config defaultUser; };
+  nixos-wsl = import ./default.nix;
 in
 {
-  imports = [
+  imports = with nixos-wsl.nixosModules; [
     "${modulesPath}/profiles/minimal.nix"
+
+    build-tarball
   ];
 
   # WSL is closer to a container than anything else
@@ -68,4 +71,5 @@ in
         ${pkgs.rsync}/bin/rsync -ar --delete $systemConfig/sw/share/$x/. /usr/share/$x
       done
     '';
+  };
 }

--- a/configuration.nix
+++ b/configuration.nix
@@ -2,18 +2,14 @@
 
 with lib;
 let
-  defaultUser = "nixos";
-  automountPath = "/mnt";
   syschdemd = import ./syschdemd.nix { inherit lib pkgs config defaultUser; };
   nixos-wsl = import ./default.nix;
 in
 {
-  imports = with nixos-wsl.nixosModules; [
+  imports = [
     "${modulesPath}/profiles/minimal.nix"
 
-    build-tarball
-    docker-desktop
-    wsl-distro
+    nixos-wsl.nixosModules.wsl
   ];
 
   wsl = {
@@ -26,7 +22,8 @@ in
     # docker.enable = true;
   };
 
-  # Enable nix-flakes by default
+  # Enable nix flakes
+  nix.package = pkgs.nixFlakes;
   nix.extraOptions = ''
     experimental-features = nix-command flakes
   '';

--- a/configuration.nix
+++ b/configuration.nix
@@ -48,17 +48,6 @@ in
   # Don't allow emergency mode, because we don't have a console.
   systemd.enableEmergencyMode = false;
 
-
-  # WSLg support
-  environment.variables = {
-    DISPLAY = ":0";
-    WAYLAND_DISPLAY = "wayland-0";
-
-    PULSE_SERVER = "${automountPath}/wslg/PulseServer";
-    XDG_RUNTIME_DIR = "${automountPath}/wslg/runtime-dir";
-    WSL_INTEROP = "/run/WSL/1_interop";
-  };
-
   environment.etc."wsl.conf".text = ''
     [automount]
     enabled=true
@@ -67,11 +56,11 @@ in
     options=metadata,uid=1000,gid=100
   '';
 
-  system.activationScripts.copy-launchers.text = ''
-    for x in applications icons; do
-      echo "Copying /usr/share/$x"
-      rm -rf /usr/share/$x
-      cp -r $systemConfig/sw/share/$x/. /usr/share/$x
-    done
-  '';
+  system.activationScripts = {
+    copy-launchers = stringAfter [] ''
+      for x in applications icons; do
+        echo "Copying /usr/share/$x"
+        ${pkgs.rsync}/bin/rsync -ar --delete $systemConfig/sw/share/$x/. /usr/share/$x
+      done
+    '';
 }

--- a/configuration.nix
+++ b/configuration.nix
@@ -33,7 +33,12 @@ in
     extraGroups = [ "root" ];
   };
 
-  security.sudo.wheelNeedsPassword = false;
+  security.sudo = {
+    extraConfig = ''
+      Defaults env_keep+=INSIDE_NAMESPACE
+    '';
+    wheelNeedsPassword = false;
+  };
 
   # Disable systemd units that don't make sense on WSL
   systemd.services."serial-getty@ttyS0".enable = false;

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,13 @@
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  {
+    src = ./.;
+  }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1617631617,
-        "narHash": "sha256-PARRCz55qN3gy07VJZIlFeOX420d0nGF0RzGI/9hVlw=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b2c27d1a81b0dc266270fa8aeecebbd1807fc610",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1618064689,
-        "narHash": "sha256-MGnHpM3bSd5JClA+1ad+jvcfNr0HrYoGmqCc2s7thkM=",
+        "lastModified": 1625876282,
+        "narHash": "sha256-z/Gv+11Uzdv3HcQCY+xGi1+iuc3rmCaPzxxDSMnuRAI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad7604ddbd9b299701fb5e15bc39cff80deffce2",
+        "rev": "068984c00e0d4e54b6684d98f6ac47c92dcb642e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1614513358,
-        "narHash": "sha256-LakhOx3S1dRjnh0b5Dg3mbZyH0ToC9I8Y2wKSkBaTzU=",
+        "lastModified": 1617631617,
+        "narHash": "sha256-PARRCz55qN3gy07VJZIlFeOX420d0nGF0RzGI/9hVlw=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5466c5bbece17adaab2d82fae80b46e807611bf3",
+        "rev": "b2c27d1a81b0dc266270fa8aeecebbd1807fc610",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1616237945,
-        "narHash": "sha256-rU+QAUxPG3BN16gBBeovz8eqITHhzewv+4o94iF57qY=",
+        "lastModified": 1618064689,
+        "narHash": "sha256-MGnHpM3bSd5JClA+1ad+jvcfNr0HrYoGmqCc2s7thkM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "66f4dc4fd1b47e9e06d0f1bd78faffa51f0cc59c",
+        "rev": "ad7604ddbd9b299701fb5e15bc39cff80deffce2",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1623875721,
@@ -32,6 +48,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
       nixosModules = {
         build-tarball = import ./modules/build-tarball.nix;
         wsl-distro = import ./modules/wsl-distro.nix;
+        docker-desktop = import ./modules/docker-desktop.nix;
       };
 
       nixosConfigurations.mysystem = nixpkgs.lib.nixosSystem {

--- a/flake.nix
+++ b/flake.nix
@@ -1,19 +1,30 @@
 {
   description = "NixOS WSL";
 
-  inputs.nixpkgs.url = "nixpkgs/nixos-20.09";
-  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-20.09";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
 
   outputs = { self, nixpkgs, flake-utils, ... }:
     {
+      nixosModules = {
+        build-tarball = import ./modules/build-tarball.nix;
+      };
+
       nixosConfigurations.mysystem = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
         modules = [
-          (import ./configuration.nix)
-          (import ./build-tarball.nix)
+          ./configuration.nix
         ];
         specialArgs = { inherit nixpkgs; };
       };
+
     } //
     flake-utils.lib.eachDefaultSystem (system:
       let

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,6 @@
         modules = [
           ./configuration.nix
         ];
-        specialArgs = { inherit nixpkgs; };
       };
 
     } //

--- a/flake.nix
+++ b/flake.nix
@@ -13,10 +13,13 @@
 
   outputs = { self, nixpkgs, flake-utils, ... }:
     {
-      nixosModules = {
-        build-tarball = import ./modules/build-tarball.nix;
-        wsl-distro = import ./modules/wsl-distro.nix;
-        docker-desktop = import ./modules/docker-desktop.nix;
+      nixosModules.wsl = {
+        imports = [
+          ./modules/build-tarball.nix
+          ./modules/wsl-distro.nix
+          ./modules/docker-desktop.nix
+          ./modules/installer.nix
+        ];
       };
 
       nixosConfigurations.mysystem = nixpkgs.lib.nixosSystem {

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
     {
       nixosModules = {
         build-tarball = import ./modules/build-tarball.nix;
+        wsl-distro = import ./modules/wsl-distro.nix;
       };
 
       nixosConfigurations.mysystem = nixpkgs.lib.nixosSystem {

--- a/modules/build-tarball.nix
+++ b/modules/build-tarball.nix
@@ -62,7 +62,7 @@ mkIf config.wsl.enable {
     # No contents, structure will be added by prepare script
     contents = [ ];
 
-    fileName = "nixos-wsl-${config.system.nixos.release}-${pkgs.hostPlatform.system}";
+    fileName = "nixos-wsl-${pkgs.hostPlatform.system}";
 
     storeContents = pkgs2storeContents [
       config.system.build.toplevel

--- a/modules/build-tarball.nix
+++ b/modules/build-tarball.nix
@@ -50,8 +50,11 @@ let
     cp ${config.environment.etc."wsl.conf".source} ./etc/wsl.conf
 
     # Copy the system configuration
-    mkdir -p ./etc/nixos
-    cp -R ${../.}/. ./etc/nixos/
+    mkdir -p ./etc/nixos/nixos-wsl
+    cp -R ${lib.cleanSource ../.}/. ./etc/nixos/nixos-wsl
+    mv ./etc/nixos/nixos-wsl/configuration.nix ./etc/nixos/configuration.nix
+    # Patch the import path to avoid havin a flake.nix in /etc/nixos
+    sed -i 's|import \./default\.nix|import \./nixos-wsl|' ./etc/nixos/configuration.nix
   '';
 
 in

--- a/modules/build-tarball.nix
+++ b/modules/build-tarball.nix
@@ -46,13 +46,18 @@ let
     # It's now a NixOS!
     touch ./etc/NIXOS
 
+    # Write wsl.conf so that it is present when NixOS is started for the first time
+    cp ${config.environment.etc."wsl.conf".source} ./etc/wsl.conf
+
     # Copy the system configuration
     mkdir -p ./etc/nixos
     cp -R ${../.}/. ./etc/nixos/
   '';
 
 in
-{
+mkIf config.wsl.enable {
+  # These options make no sense without the wsl-distro module anyway
+
   system.build.tarball = pkgs.callPackage "${nixpkgs}/nixos/lib/make-system-tarball.nix" {
     # No contents, structure will be added by prepare script
     contents = [ ];
@@ -71,4 +76,5 @@ in
     compressCommand = "gzip";
     compressionExtension = ".gz";
   };
+
 }

--- a/modules/docker-desktop.nix
+++ b/modules/docker-desktop.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+with builtins; with lib; {
+
+  options.wsl.docker = with types; {
+    enable = mkEnableOption "Docker Desktop integration";
+  };
+
+  config =
+    let
+      cfg = config.wsl.docker;
+    in
+    mkIf (config.wsl.enable && cfg.enable) {
+
+      environment.systemPackages = with pkgs; [
+        docker
+        docker-compose
+      ];
+
+      systemd.services.docker-desktop-proxy = {
+        description = "Docker Desktop proxy";
+        script = ''
+          ${config.wsl.automountPath}/wsl/docker-desktop/docker-desktop-proxy -docker-desktop-root ${config.wsl.automountPath}/wsl/docker-desktop
+        '';
+        wantedBy = [ "multi-user.target" ];
+      };
+
+      users.groups.docker.members = [
+        config.wsl.defaultUser
+      ];
+
+    };
+
+}

--- a/modules/docker-desktop.nix
+++ b/modules/docker-desktop.nix
@@ -22,6 +22,10 @@ with builtins; with lib; {
           ${config.wsl.automountPath}/wsl/docker-desktop/docker-desktop-proxy -docker-desktop-root ${config.wsl.automountPath}/wsl/docker-desktop
         '';
         wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Restart = "on-failure";
+          RestartSec = "30s";
+        };
       };
 
       users.groups.docker.members = [

--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -1,0 +1,88 @@
+{ config, lib, pkgs, ... }:
+with builtins; with lib; {
+
+  config = mkIf config.wsl.enable (
+    let
+      mkTarball = pkgs.callPackage "${lib.cleanSource pkgs.path}/nixos/lib/make-system-tarball.nix";
+
+      busybox-static = pkgs.busybox.override { enableStatic = true; };
+
+      pkgs2storeContents = map (x: { object = x; symlink = "none"; });
+
+      installerDependencies = mkTarball {
+        fileName = "store";
+        compressCommand = "cat";
+        compressionExtension = "";
+        contents = [ ];
+        storeContents = with pkgs; pkgs2storeContents [
+          pv
+        ];
+      };
+
+      installer = pkgs.writeScript "installer.sh" ''
+        #!/bin/sh
+        set -e
+        cd /
+
+        echo "Unpacking installer..."
+        tar xf /store.tar
+
+        echo "Unpacking root file system..."
+        ${pkgs.pv}/bin/pv /rootfs.tar.gz | tar xz
+
+        echo "Cleaning up installer files..."
+        rm /rootfs.tar.gz /store.tar /installer.sh
+
+        echo "Activating nix configuration..."
+        /nix/var/nix/profiles/system/activate
+
+        echo "Starting systemd..."
+        exec ${config.users.users.root.shell}
+      '';
+
+      # Set installer.sh as the root shell
+      passwd = pkgs.writeText "passwd" ''
+        root:x:0:0:System administrator:/root:/installer.sh
+      '';
+    in
+    {
+
+      system.build.installer = mkTarball {
+        fileName = "nixos-wsl-installer";
+        compressCommand = "gzip";
+        compressionExtension = ".gz";
+
+        contents = [
+          {
+            source = let tarball = config.system.build.tarball; in "${tarball}/tarball/${tarball.fileName}.tar${tarball.extension}";
+            target = "/rootfs.tar.gz";
+          }
+          { source = "${installerDependencies}/tarball/store.tar"; target = "/store.tar"; }
+          { source = "${busybox-static}/bin/busybox"; target = "/bin/busybox"; }
+          { source = config.environment.etc."wsl.conf".source; target = "/etc/wsl.conf"; }
+          { source = passwd; target = "/etc/passwd"; }
+          { source = installer; target = "/installer.sh"; }
+        ];
+
+        extraCommands =
+          let
+            # WSL's --import does not like hardlinks, create symlinks instead
+            createBusyboxLinks = concatStringsSep "\n" (
+              mapAttrsToList
+                (applet: type: "ln -s /bin/busybox ./bin/${applet}")
+                (filterAttrs
+                  (applet: type: applet != "busybox") # don't overwrite the original busybox
+                  (readDir "${busybox-static}/bin")
+                )
+            );
+          in
+          pkgs.writeShellScript "busybox-setup" ''
+            set -e
+            ${createBusyboxLinks}
+          '';
+      };
+
+    }
+  );
+
+}

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -86,6 +86,7 @@ with builtins; with lib;
         stringAfter [ ] ''
           for x in applications icons; do
             echo "Copying /usr/share/$x"
+            mkdir -p /usr/share/$x
             ${pkgs.rsync}/bin/rsync -ar --delete $systemConfig/sw/share/$x/. /usr/share/$x
           done
         ''

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -1,0 +1,107 @@
+{ lib, pkgs, config, ... }:
+
+with builtins; with lib;
+{
+  options.wsl = with types;
+    let
+      coercedToStr = coercedTo (oneOf [ bool path int ]) (toString) str;
+    in
+    {
+      enable = mkEnableOption "support for running NixOS as a WSL distribution";
+      automountPath = mkOption {
+        type = str;
+        default = "/mnt";
+        description = "The path where windows drives are mounted (e.g. /mnt/c)";
+      };
+      automountOptions = mkOption {
+        type = str;
+        default = "metadata,uid=1000,gid=100";
+        description = "Options to use when mounting windows drives";
+      };
+      defaultUser = mkOption {
+        type = str;
+        default = "nixos";
+        description = "The name of the default user";
+      };
+      startMenuLaunchers = mkEnableOption "shortcuts for GUI applications in the windows start menu";
+      wslConf = mkOption {
+        type = attrsOf (attrsOf coercedToStr);
+        description = "Entries that are added to /etc/wsl.conf";
+      };
+    };
+
+  config =
+    let
+      cfg = config.wsl;
+      syschdemd = import ../syschdemd.nix { inherit lib pkgs config; defaultUser = cfg.defaultUser; };
+    in
+    mkIf cfg.enable {
+
+      wsl.wslConf = {
+        automount = {
+          enabled = true;
+          mountFsTab = true;
+          root = "${cfg.automountPath}/";
+          options = cfg.automountOptions;
+        };
+      };
+
+      # WSL is closer to a container than anything else
+      boot.isContainer = true;
+
+      environment = {
+        # Include Windows %PATH% in Linux $PATH.
+        extraInit = ''PATH="$PATH:$WSLPATH"'';
+
+        etc = {
+          "wsl.conf".text = generators.toINI { } cfg.wslConf;
+
+          # DNS settings are managed by WSL
+          hosts.enable = false;
+          "resolv.conf".enable = false;
+        };
+      };
+
+      networking.dhcpcd.enable = false;
+
+      users.users.${cfg.defaultUser} = {
+        isNormalUser = true;
+        extraGroups = [ "wheel" ]; # Allow the default user to use sudo
+      };
+
+      users.users.root = {
+        shell = "${syschdemd}/bin/syschdemd";
+        # Otherwise WSL fails to login as root with "initgroups failed 5"
+        extraGroups = [ "root" ];
+      };
+
+      security.sudo = {
+        extraConfig = ''
+          Defaults env_keep+=INSIDE_NAMESPACE
+        '';
+        wheelNeedsPassword = mkDefault false; # The default user will not have a password by default
+      };
+
+      system.activationScripts.copy-launchers = mkIf cfg.startMenuLaunchers (
+        stringAfter [ ] ''
+          for x in applications icons; do
+            echo "Copying /usr/share/$x"
+            ${pkgs.rsync}/bin/rsync -ar --delete $systemConfig/sw/share/$x/. /usr/share/$x
+          done
+        ''
+      );
+
+      # Disable systemd units that don't make sense on WSL
+      systemd.services."serial-getty@ttyS0".enable = false;
+      systemd.services."serial-getty@hvc0".enable = false;
+      systemd.services."getty@tty1".enable = false;
+      systemd.services."autovt@".enable = false;
+
+      systemd.services.firewall.enable = false;
+      systemd.services.systemd-resolved.enable = false;
+      systemd.services.systemd-udevd.enable = false;
+
+      # Don't allow emergency mode, because we don't have a console.
+      systemd.enableEmergencyMode = false;
+    };
+}

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -48,6 +48,7 @@ with builtins; with lib;
 
       # WSL is closer to a container than anything else
       boot.isContainer = true;
+      environment.noXlibs = lib.mkForce false; # override xlibs not being installed (due to isContainer) to enable the use of GUI apps
 
       environment = {
         # Include Windows %PATH% in Linux $PATH.

--- a/nixos.nix
+++ b/nixos.nix
@@ -2,12 +2,7 @@
 #   nix-build -A system -A config.system.build.tarball ./nixos.nix
 
 import <nixpkgs/nixos> {
-  configuration = {
-    imports = [
-      ./configuration.nix
-      ./build-tarball.nix
-    ];
-  };
+  configuration = import ./configuration.nix;
 
   system = "x86_64-linux";
 }

--- a/nixos.nix
+++ b/nixos.nix
@@ -1,8 +1,0 @@
-# Build with
-#   nix-build -A system -A config.system.build.tarball ./nixos.nix
-
-import <nixpkgs/nixos> {
-  configuration = import ./configuration.nix;
-
-  system = "x86_64-linux";
-}

--- a/syschdemd.sh
+++ b/syschdemd.sh
@@ -40,4 +40,4 @@ if [[ $# -gt 0 ]]; then
 else
     cmd="$userShell"
 fi
-exec $sw/nsenter -t $(< /run/systemd.pid) -p -m -- $sw/machinectl -q --uid=@defaultUser@ shell .host /bin/sh -c "cd \"$PWD\"; exec $cmd"
+exec $sw/nsenter -t $(< /run/systemd.pid) -p -m -- $sw/machinectl -q --uid=@defaultUser@ shell .host /bin/sh --login -c "cd \"$PWD\"; exec $cmd"

--- a/syschdemd.sh
+++ b/syschdemd.sh
@@ -47,7 +47,7 @@ exportCmd="$(export -p | $sw/grep -vE ' (HOME|LOGNAME|SHELL|USER)='); export WSL
 if [ -z "${INSIDE_NAMESPACE:-}" ]; then
     exec $sw/nsenter -t $(</run/systemd.pid) -p -m -- $sw/machinectl -q \
         --uid=@defaultUser@ shell .host /bin/sh -c \
-        "cd \"$PWD\"; $exportCmd; exec $cmd"
+        "cd \"$PWD\"; $exportCmd; source /etc/set-environment; exec $cmd"
 else
     exec $cmd
 fi

--- a/syschdemd.sh
+++ b/syschdemd.sh
@@ -3,7 +3,7 @@
 set -e
 
 sw="/nix/var/nix/profiles/system/sw/bin"
-systemPath=`${sw}/readlink -f /nix/var/nix/profiles/system`
+systemPath=$(${sw}/readlink -f /nix/var/nix/profiles/system)
 
 # Needs root to work
 if [[ $EUID -ne 0 ]]; then
@@ -19,16 +19,16 @@ if [ ! -e "/run/systemd.pid" ]; then
     PATH=/run/current-system/systemd/lib/systemd:@fsPackagesPath@ \
         LOCALE_ARCHIVE=/run/current-system/sw/lib/locale/locale-archive \
         @daemonize@/bin/daemonize /run/current-system/sw/bin/unshare -fp --mount-proc systemd
-    /run/current-system/sw/bin/pgrep -xf systemd > /run/systemd.pid
+    /run/current-system/sw/bin/pgrep -xf systemd >/run/systemd.pid
 
     # Wait for systemd to start
     status=1
     while [[ $status -gt 0 ]]; do
         $sw/sleep 1
         status=0
-        $sw/nsenter -t $(< /run/systemd.pid) -p -m -- \
-                    $sw/systemctl is-system-running -q --wait 2>/dev/null \
-            || status=$?
+        $sw/nsenter -t $(</run/systemd.pid) -p -m -- \
+            $sw/systemctl is-system-running -q --wait 2>/dev/null ||
+            status=$?
     done
 fi
 
@@ -42,8 +42,12 @@ else
 fi
 
 # Pass external environment but filter variables specific to root user.
-exportCmd="$(export -p | $sw/grep -vE ' (HOME|LOGNAME|SHELL|USER)='); export WSLPATH=\"$PATH\""
+exportCmd="$(export -p | $sw/grep -vE ' (HOME|LOGNAME|SHELL|USER)='); export WSLPATH=\"$PATH\"; export INSIDE_NAMESPACE=true"
 
-exec $sw/nsenter -t $(< /run/systemd.pid) -p -m -- $sw/machinectl -q \
-	--uid=@defaultUser@ shell .host /bin/sh -c \
-	"cd \"$PWD\"; $exportCmd; exec $cmd"
+if [ -z "${INSIDE_NAMESPACE:-}" ]; then
+    exec $sw/nsenter -t $(</run/systemd.pid) -p -m -- $sw/machinectl -q \
+        --uid=@defaultUser@ shell .host /bin/sh -c \
+        "cd \"$PWD\"; $exportCmd; exec $cmd"
+else
+    exec $cmd
+fi


### PR DESCRIPTION
The changes that I have implemented in my fork of this repo can't be separated easily anymore, so I have put all of them in one PR.

#53, #45 and #39 are integrated in this pull request

- The configuration has been split into multiple modules, which are exposed through the flake
	- the system configuration accesses the flake using flake-compat, so that it can be built without a flake-enabled nix
- Optional Docker Desktop support (can be enabled in configuration.nix)
- nixos.nix has been removed in favor of using flake-compat for nix-build. The CI pipeline has been adjusted accordingly
- syschdemd.sh loads /etc/set-environment before starting a command. This makes  the WSL-Remote in VSCode work if https://github.com/msteen/nixos-vscode-server is used
- A module has been added to build an installer tarball.
    - This wraps around the system tarball and should be used with `wsl --import` instead. Importing the system tarball can fail with an "Unspecified Error". One of the causes for this error (at least in my testing) is any hard-link being present in the tarball. The installer mitigates this issue by including only a statically-compiled version of busybox, that is used to unpack the system tarball when starting the system for the first time

Fixes #30
Fixes #32
Fixes #34
Fixes #35
Fixes #50
Fixes #51
Fixes #57 