### PR TITLE
Fix Windows File Systems not being mounted on first start when using the Installer

### DIFF
--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -54,7 +54,10 @@ with builtins; with lib; {
 
         contents = [
           { source = config.environment.etc."wsl.conf".source; target = "/etc/wsl.conf"; }
+          { source = config.environment.etc."fstab".source; target = "/etc/fstab"; }
           { source = passwd; target = "/etc/passwd"; }
+          { source = "${pkgs.busybox}/bin/busybox"; target = "/bin/sh"; }
+          { source = "${pkgs.busybox}/bin/busybox"; target = "/bin/mount"; }
         ];
       };
 

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -47,7 +47,7 @@ with builtins; with lib;
   config =
     let
       cfg = config.wsl;
-      syschdemd = import ../syschdemd.nix { inherit lib pkgs config; defaultUser = cfg.defaultUser; };
+      syschdemd = import ../syschdemd.nix { inherit lib pkgs config; defaultUser = cfg.defaultUser; defaultUserHome = config.users.users.${cfg.defaultUser}.home; };
     in
     mkIf cfg.enable {
 

--- a/syschdemd.nix
+++ b/syschdemd.nix
@@ -1,4 +1,10 @@
-{ lib, pkgs, config, defaultUser, ... }:
+{ lib
+, pkgs
+, config
+, defaultUser
+, defaultUserHome ? "/home/${defaultUser}"
+, ...
+}:
 
 pkgs.substituteAll {
   name = "syschdemd";
@@ -8,8 +14,8 @@ pkgs.substituteAll {
 
   buildInputs = with pkgs; [ daemonize ];
 
+  inherit defaultUser defaultUserHome;
   inherit (pkgs) daemonize;
-  inherit defaultUser;
   inherit (config.security) wrapperDir;
   fsPackagesPath = lib.makeBinPath config.system.fsPackages;
 


### PR DESCRIPTION
Add a `/bin/mount` binary to the installer, so that WSL can correctly mount the file systems
`/etc/fstab` is not required, but an error appears if it is not present

When the shell is started in `/root`, syschdemd now silently changes to the default user's home directory, in order to prevent an error message from appearing. This happens, when WSL is started in a directory, that is not available in the guest fs

Closes #72