### PR TITLE
Add docker-native module for native docker support in NixOS

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -19,6 +19,9 @@ in
 
     # Enable integration with Docker Desktop (needs to be installed)
     # docker.enable = true;
+
+    # Enable native Docker support within NixOS
+    # docker-native.enable = true;
   };
 
   # Enable nix flakes

--- a/configuration.nix
+++ b/configuration.nix
@@ -17,11 +17,12 @@ in
     defaultUser = "nixos";
     startMenuLaunchers = true;
 
+    # Enable native Docker support
+    # docker-native.enable = true;
+
     # Enable integration with Docker Desktop (needs to be installed)
     # docker-desktop.enable = true;
 
-    # Enable native Docker support within NixOS
-    # docker-native.enable = true;
   };
 
   # Enable nix flakes

--- a/configuration.nix
+++ b/configuration.nix
@@ -18,7 +18,7 @@ in
     startMenuLaunchers = true;
 
     # Enable integration with Docker Desktop (needs to be installed)
-    # docker.enable = true;
+    # docker-desktop.enable = true;
 
     # Enable native Docker support within NixOS
     # docker-native.enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
           ./modules/wsl-distro.nix
           ./modules/docker-desktop.nix
           ./modules/installer.nix
+          ./modules/docker-native.nix
         ];
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,8 @@
           ./modules/build-tarball.nix
           ./modules/wsl-distro.nix
           ./modules/docker-desktop.nix
-          ./modules/installer.nix
           ./modules/docker-native.nix
+          ./modules/installer.nix
         ];
       };
 

--- a/modules/docker-desktop.nix
+++ b/modules/docker-desktop.nix
@@ -1,13 +1,17 @@
 { config, lib, pkgs, ... }:
 with builtins; with lib; {
 
-  options.wsl.docker = with types; {
+  imports = [
+    (mkRenamedOptionModule [ "wsl" "docker" ] [ "wsl" "docker-desktop" ])
+  ];
+
+  options.wsl.docker-desktop = with types; {
     enable = mkEnableOption "Docker Desktop integration";
   };
 
   config =
     let
-      cfg = config.wsl.docker;
+      cfg = config.wsl.docker-desktop;
     in
     mkIf (config.wsl.enable && cfg.enable) {
 

--- a/modules/docker-native.nix
+++ b/modules/docker-native.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+with builtins; with lib; {
+
+  options.wsl.docker-native = with types; {
+    enable = mkEnableOption "Native Docker integration in NixOS.";
+  };
+
+  config =
+    let
+      cfg = config.wsl.docker-native;
+    in
+    mkIf (config.wsl.enable && cfg.enable) {
+      nixpkgs.overlays = [
+        (self: super: {
+          docker = super.docker.override { iptables = pkgs.iptables-legacy; };
+        })
+      ];
+
+      environment.systemPackages = with pkgs; [
+        docker
+        docker-compose
+      ];
+
+      virtualisation.docker.enable = true;
+
+      users.groups.docker.members = [
+        config.wsl.defaultUser
+      ];
+    };
+
+}


### PR DESCRIPTION
Addresses [#59](https://github.com/nix-community/NixOS-WSL/issues/59#issuecomment-1092657189) by overlaying legacy iptables on the docker package.