### PR TITLE
Preserve UID for default user

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -91,6 +91,7 @@ with builtins; with lib;
 
       users.users.${cfg.defaultUser} = {
         isNormalUser = true;
+        uid = 1000;
         extraGroups = [ "wheel" ]; # Allow the default user to use sudo
       };
 


### PR DESCRIPTION
`/mnt/wslg/runtime-dir` is owned by user ID 1000, as noted in [this post](https://github.com/microsoft/wslg/discussions/144), which is always the first user created on the system. I changed my `configuration.nix` to use a different user name by using the provided `defaultUser` parameter. However, on rebuild, this causes NixOS to create an entirely new user with ID 1001, which then causes strange behavior with wslg, because programs like emacs will emit errors like:

    unable to create directory "/mnt/wslg/runtime-dir/dconf"

This is because they can't write to `runtime-dir`. The fix for this is easy: simply force the default user to have ID 1000, which fixes the problem.