### PR TITLE
docker-desktop: fix bind mounts

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -61,7 +61,7 @@ with builtins; with lib;
   config =
     let
       cfg = config.wsl;
-      syschdemd = import ../syschdemd.nix { inherit lib pkgs config; defaultUser = cfg.defaultUser; defaultUserHome = config.users.users.${cfg.defaultUser}.home; };
+      syschdemd = import ../syschdemd.nix { inherit lib pkgs config; inherit (cfg) automountPath defaultUser; defaultUserHome = config.users.users.${cfg.defaultUser}.home; };
     in
     mkIf cfg.enable {
 

--- a/syschdemd.nix
+++ b/syschdemd.nix
@@ -1,6 +1,7 @@
 { lib
 , pkgs
 , config
+, automountPath
 , defaultUser
 , defaultUserHome ? "/home/${defaultUser}"
 , ...
@@ -21,6 +22,7 @@ pkgs.substituteAll {
 
   systemdWrapper = pkgs.writeShellScript "systemd-wrapper.sh" ''
     mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc || true
+    mount --make-rshared ${automountPath}
     exec systemd
   '';
 }

--- a/syschdemd.sh
+++ b/syschdemd.sh
@@ -8,14 +8,12 @@ systemPath=$(${sw}/readlink -f /nix/var/nix/profiles/system)
 function start_systemd {
     echo "Starting systemd..." >&2
 
-    @wrapperDir@/umount /proc/sys/fs/binfmt_misc || true
-
     PATH=/run/current-system/systemd/lib/systemd:@fsPackagesPath@ \
         LOCALE_ARCHIVE=/run/current-system/sw/lib/locale/locale-archive \
         @daemonize@/bin/daemonize /run/current-system/sw/bin/unshare -fp --mount-proc @systemdWrapper@
 
     # Wait until systemd has been started to prevent a race condition from occuring
-    while ! /run/current-system/sw/bin/pgrep -xf systemd >/run/systemd.pid; do
+    while ! $sw/pgrep -xf systemd | $sw/tail -n1 >/run/systemd.pid; do
         $sw/sleep 1s
     done
 


### PR DESCRIPTION
The `/mnt` mount gets marked as shared in the systemd wrapper script, so that the bind mounts created by the docker desktop proxy are present outside the systemd namespace

See also #89 #90

@hschaeidt 