### PR TITLE
Fix syschdemd exit code

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -145,6 +145,9 @@ with builtins; with lib;
           enableEmergencyMode = false;
         };
 
+        # Start a systemd user session when starting a command through runuser
+        security.pam.services.runuser.startSession = true;
+
         warnings = (optional (config.systemd.services.systemd-resolved.enable && config.wsl.wslConf.network.generateResolvConf) "systemd-resolved is enabled, but resolv.conf is managed by WSL");
       })
       (mkIf (!cfg.nativeSystemd) {

--- a/scripts/syschdemd.nix
+++ b/scripts/syschdemd.nix
@@ -7,6 +7,7 @@
 , gnugrep
 , systemd
 , util-linux
+, which
 , defaultUser
 , automountPath
 ,
@@ -45,6 +46,7 @@ mkWrappedScript {
     gnugrep
     systemd # machinectl
     util-linux # nsenter, runuser
+    which
     wrapper
   ];
   username = defaultUser.name;

--- a/scripts/syschdemd.nix
+++ b/scripts/syschdemd.nix
@@ -44,10 +44,9 @@ mkWrappedScript {
     glibc # getent
     gnugrep
     systemd # machinectl
-    util-linux # nsenter
+    util-linux # nsenter, runuser
     wrapper
   ];
   username = defaultUser.name;
-  uid = defaultUser.uid;
   inherit automountPath;
 }

--- a/scripts/syschdemd.sh
+++ b/scripts/syschdemd.sh
@@ -126,7 +126,6 @@ main() {
   run_in_namespace \
     systemd-run \
     --quiet \
-    --uid=@uid@ \
     --collect \
     --wait \
     --pty \
@@ -135,7 +134,7 @@ main() {
     --setenv=WSLPATH="$(clean_wslpath)" \
     --working-directory="$PWD" \
     --machine=.host \
-    /bin/sh -c "$exportCmd; source /etc/set-environment; exec $command"
+    "$(which runuser)" -u @username@ -- /bin/sh -c "$exportCmd; source /etc/set-environment; exec $command"
 }
 
 main "$@"


### PR DESCRIPTION
This fixes #138, by using systemd-run instead of machinectl, but breaks systemd user sessions and dbus

@K900: If we can get those to work with systemd-run, it will probably work with native systemd as well (because I think this is what MS is using as well)