### PR TITLE
Do not import minimal profile by default

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -6,8 +6,6 @@ let
 in
 {
   imports = [
-    "${modulesPath}/profiles/minimal.nix"
-
     nixos-wsl.nixosModules.wsl
   ];
 


### PR DESCRIPTION
- `environment.noXlibs` breaks often things and is a hassle to use
- `documentation.enable` having documentation available is desired
- `documentation.nixos.enable` removes the man page for nixos-rebuild which is triggered by --help
- `programs.command-not-found.enable` also command-not-found is useful

see https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/profiles/minimal.nix