### PR TITLE
remove boot.isContainer

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -50,10 +50,16 @@ with builtins; with lib;
         };
       };
 
-      # WSL is closer to a container than anything else
-      boot.isContainer = true;
+      # We don't need a boot loader
+      boot.loader.grub.enable = false;
+      system.build.installBootLoader = pkgs.writeShellScript "fake-bootloader" "";
+      boot.initrd.enable = false;
+      system.build.initialRamdisk = pkgs.runCommand "fake-initrd" { } ''
+        mkdir $out
+        touch $out/${config.system.boot.loader.initrdFile}
+      '';
+      system.build.initialRamdiskSecretAppender = pkgs.writeShellScriptBin "append-initrd-secrets" "";
 
-      environment.noXlibs = lib.mkForce false; # override xlibs not being installed (due to isContainer) to enable the use of GUI apps
       hardware.opengl.enable = true; # Enable GPU acceleration
 
       environment = {

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -52,7 +52,7 @@ with builtins; with lib;
 
       # We don't need a boot loader
       boot.loader.grub.enable = false;
-      system.build.installBootLoader = pkgs.writeShellScript "fake-bootloader" "";
+      system.build.installBootLoader = "${pkgs.coreutils}/bin/true"
       boot.initrd.enable = false;
       system.build.initialRamdisk = pkgs.runCommand "fake-initrd" { } ''
         mkdir $out

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -52,7 +52,7 @@ with builtins; with lib;
 
       # We don't need a boot loader
       boot.loader.grub.enable = false;
-      system.build.installBootLoader = "${pkgs.coreutils}/bin/true"
+      system.build.installBootLoader = "${pkgs.coreutils}/bin/true";
       boot.initrd.enable = false;
       system.build.initialRamdisk = pkgs.runCommand "fake-initrd" { } ''
         mkdir $out


### PR DESCRIPTION
Do not set boot.isContainer to true, but set the required options directly. This gets around some quirks isContainer introduces in other modules (especially one in PAM that is related to solving #138). This might introduce issues related to `udev`, `audit` and `modprobe`, which get activated by removing that option; though i have not encountered any so far