### PR TITLE
docker-native: switch nixpkgs.overlays to inline overlay

### DIFF
--- a/modules/docker-native.nix
+++ b/modules/docker-native.nix
@@ -20,17 +20,11 @@ with builtins; with lib; {
       cfg = config.wsl.docker-native;
     in
     mkIf (config.wsl.enable && cfg.enable) {
-      nixpkgs.overlays = [
-        (self: super: {
-          docker = super.docker.override { iptables = pkgs.iptables-legacy; };
-        })
-      ];
-
       environment.systemPackages = with pkgs; [
-        docker
         docker-compose
       ];
 
+      virtualisation.docker.package = (pkgs.docker.override { iptables = pkgs.iptables-legacy; });
       virtualisation.docker.enable = true;
 
       users.groups.docker.members = lib.mkIf cfg.addToDockerGroup [


### PR DESCRIPTION
This makes possible for some NixOS-WSL system configs managed by a flake to use the iptables-legacy overlay, since nixpkgs.overlays could not work depending on how you use your flake. [Here's some example to a person trying to use an overlay in a flake managed system](https://discourse.nixos.org/t/how-to-apply-an-overlay-defined-in-one-flake-in-my-flake/11987)

Besides this being more readable (at least for me ). this essentially makes no difference to working machines since it's just overriding the iptables package to the legacy one.
