### PR TITLE
Fix permissions for files in /dev/pts

### DIFF
--- a/scripts/syschdemd.sh
+++ b/scripts/syschdemd.sh
@@ -134,7 +134,7 @@ main() {
     --setenv=WSLPATH="$(clean_wslpath)" \
     --working-directory="$PWD" \
     --machine=.host \
-    "$(which runuser)" -u @username@ -- /bin/sh -c "$exportCmd; source /etc/set-environment; exec $command"
+    "$(which runuser)" --pty -u @username@ -- /bin/sh -c "$exportCmd; source /etc/set-environment; exec $command"
 }
 
 main "$@"


### PR DESCRIPTION
The pts should have $USER:tty permissions, not root:tty. This broke gpg with the following not very helpful error message:
gpg: signing failed: Permission denied