### PR TITLE
Fix sudo ssh with jumpHost

### DIFF
--- a/scripts/syschdemd.sh
+++ b/scripts/syschdemd.sh
@@ -111,7 +111,7 @@ main() {
 
   # If we're executed from inside the container, e.g. sudo
   if is_in_container; then
-    exec $command
+    eval $command
   fi
 
   # If we are currently in /root, this is probably because the directory that WSL was started is inaccessible


### PR DESCRIPTION
sudo ssh with JumpHost is right now broken.
``/nix/store/x411w196j7fvznixm9517mya5g3rhnvs-syschdemd/bin/.syschdemd-wrapped: line 114: exec: exec: not found``

```
sudo NIXOS_WSL_DEBUG=1 ssh host
+ rundir=/run/nixos-wsl
+ pidfile=/run/nixos-wsl/unshare.pid
+ main -c 'exec ssh -l tunnel -W '\''[host]:22'\'' jumpHost'
+ ensure_root
+ '[' 0 -ne 0 ']'
+ '[' '!' -e /run/current-system ']'
+ '[' '!' -e /run/nixos-wsl ']'
+ is_in_container
+ '[' true == true ']'
+ '[' 2 -gt 0 ']'
+ shift
+ command='exec ssh -l tunnel -W '\''[host]:22'\'' jumpHost'
+ is_in_container
+ '[' true == true ']'
+ exec exec ssh -l tunnel -W ''\''[host]:22'\''' jumpHost
/nix/store/x411w196j7fvznixm9517mya5g3rhnvs-syschdemd/bin/.syschdemd-wrapped: line 114: exec: exec: not found
kex_exchange_identification: Connection closed by remote host
Connection closed by UNKNOWN port 65535
```

This PR fixes that.