### PR TITLE
Setup /bin/login for native systemd support

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -146,6 +146,11 @@ with lib; {
               mkdir -p /sbin
               ln -sf ${shim}/bin/nixos-wsl-native-systemd-shim /sbin/init
             '';
+            setupLogin = stringAfter [ ] ''
+              echo "setting up /bin/login..."
+              mkdir -p /bin
+              ln -sf ${pkgs.shadow}/bin/login /bin/login
+            '';
           };
 
           environment = {


### PR DESCRIPTION
When native systemd integration is enabled in WSL, it looks for /bin/login to login the user.

It enables proper support for user session (dbus and systemd).

Resolves issue #165.