### PR TITLE
Fix X11 socket symlink creation

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -118,11 +118,6 @@ with lib; {
               systemd-udevd.enable = false;
             };
 
-            tmpfiles.rules = [
-              # Don't remove the X11 socket
-              "d /tmp/.X11-unix 1777 root root"
-            ];
-
             # Don't allow emergency mode, because we don't have a console.
             enableEmergencyMode = false;
           };


### PR DESCRIPTION
by updating the tmpfile.d rule to match the one created by upstream WSL

Or do we just want to remove this?