### PR TITLE
nixos-wsl-version command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,13 @@ on:
   workflow_call: {}
 
 jobs:
-  find-tests:
-    name: Find Tests 🔍
+  prepare:
+    name: Prepare 🚀
     runs-on: ubuntu-latest
     outputs:
       tests: ${{ steps.tests.outputs.tests }}
       checks: ${{ steps.checks.outputs.checks }}
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -31,8 +32,20 @@ jobs:
         run: |
           nix-instantiate --json --eval --strict -E 'with builtins; attrNames (getFlake (toString ./.)).checks.${currentSystem}' | perl -pe 's|(.*)|checks=\1|' >>$GITHUB_OUTPUT
 
+      - name: Generate Version 🏷️
+        id: version
+        run: |
+          TAG_COUNT=$(git rev-list --tags --no-walk --count)                                                                 # Count all tags
+          COMMIT_COUNT=$(git rev-list --use-bitmap-index --count $(git rev-list --tags --no-walk --max-count=1)..HEAD)       # Count all commits since the last tag
+          NIXOS_VERSION=$(nix-instantiate --eval -E '(import ./.).inputs.nixpkgs.lib.version' | sed -E 's/"(.+\...).*"/\1/') # Get NixOS version from nixpkgs
+          NIXOS_VERSION_MS=$(echo $NIXOS_VERSION | sed -E 's/\.0*(.+)/\.\1/')                                                # Remove the leading 0 from the minor version (if it exists)
+          NIXOS_WSL_VERSION=${NIXOS_VERSION_MS}.${TAG_COUNT}.${COMMIT_COUNT}                                                 # Compose the NixOS-WSL version number
+          echo "version=$NIXOS_WSL_VERSION" >> $GITHUB_OUTPUT
+
   build:
     name: Build 🛠️
+    needs:
+      - prepare
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,6 +55,11 @@ jobs:
 
       - name: Install nix ❄️
         uses: cachix/install-nix-action@v18
+
+      - name: Set version 🏷️
+        run: |
+          echo ${{ needs.prepare.outputs.version }} > ./VERSION
+          echo $(git rev-parse HEAD) >> ./VERSION
 
       - name: Build installer 🛠️
         run: |
@@ -56,11 +74,11 @@ jobs:
   checks:
     name: Flake Check 📋
     needs:
-      - find-tests
+      - prepare
     strategy:
       fail-fast: false
       matrix:
-        check: ${{ fromJSON(needs.find-tests.outputs.checks) }}
+        check: ${{ fromJSON(needs.prepare.outputs.checks) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -78,12 +96,12 @@ jobs:
   tests:
     name: Test 🧪
     needs:
-      - find-tests
+      - prepare
       - build
     strategy:
       fail-fast: false
       matrix:
-        test: ${{ fromJSON(needs.find-tests.outputs.tests) }}
+        test: ${{ fromJSON(needs.prepare.outputs.tests) }}
         os:
           - ubuntu-20.04
           # - windows-latest # doesn't work due to lack of nested virtualization on the runners, hopefully this will work one day

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,2 @@
+DEV_BUILD
+dirty

--- a/flake.lock
+++ b/flake.lock
@@ -33,17 +33,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670625113,
-        "narHash": "sha256-3XuCP1b8U0/rzvQciowoM6sZjtq7nYzHOFUcNRa0WhY=",
+        "lastModified": 1671215800,
+        "narHash": "sha256-2W54K41A7MefEaWzgL/TsaWlhKRK/RhWUybyOW4i0K8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8ec26f41fd94805d8fbf2552d8e7a449612c08e",
+        "rev": "9d692a724e74d2a49f7c985132972f991d144254",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "NixOS",
         "ref": "nixos-22.11",
-        "type": "indirect"
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@
   };
 
   outputs = inputs@{ self, nixpkgs, flake-utils, ... }:
+    with nixpkgs.lib;
     {
 
       nixosModules.wsl = {
@@ -21,8 +22,13 @@
           ./modules/docker-native.nix
           ./modules/installer.nix
           ./modules/interop.nix
+          ./modules/version.nix
           ./modules/wsl-conf.nix
           ./modules/wsl-distro.nix
+
+          ({ ... }: {
+            wsl.version.rev = mkIf (self ? rev) self.rev;
+          })
         ];
       };
 

--- a/modules/version.nix
+++ b/modules/version.nix
@@ -1,0 +1,79 @@
+{ lib, pkgs, options, config, ... }:
+with builtins; with lib;
+{
+
+  options = with types; {
+    wsl.version =
+      let
+        versionFile = splitString "\n" (readFile ../VERSION);
+      in
+      {
+        release = mkOption {
+          description = "the NixOS-WSL release";
+          type = str;
+          default = elemAt versionFile 0;
+        };
+        rev = mkOption {
+          description = "the NixOS-WSL git revision";
+          type = str;
+          default = elemAt versionFile 1;
+        };
+        systemd = mkOption {
+          type = enum [ "native" "syschdemd" ];
+          description = "the systemd implementation used by NixOS-WSL";
+          default = if config.wsl.nativeSystemd then "native" else "syschdemd";
+        };
+      };
+  };
+
+  config = mkIf config.wsl.enable {
+
+    environment.systemPackages = [
+      (
+        with config.wsl.version;
+        let
+          opts = options.wsl.version;
+          maxlen = foldl (acc: opt: max acc (stringLength opt)) 0 ((attrNames opts) ++ [ "help" "json" ]);
+          rightPad = text: "${text}${fixedWidthString (2 + maxlen - (stringLength text)) " " ""}";
+        in
+        pkgs.writeShellScriptBin "nixos-wsl-version" ''
+          for arg in "$@"; do
+            case $arg in
+              --help)
+                echo "Usage: nixos-wsl-version [option]"
+                echo "Options:"
+                echo -e "  --${rightPad "help"}Show this help message"
+                ${concatStringsSep "\n" (
+                  mapAttrsToList (option: value: ''
+                    echo "  --${rightPad option}Show ${value.description}"
+                  '') opts
+                )}
+                echo -e "  --${rightPad "json"}Show everything in JSON format"
+                exit 0
+                ;;
+              ${concatStringsSep "\n" (
+                mapAttrsToList (option: value: ''
+                  --${option})
+                  echo ${value}
+                  exit 0
+                  ;;
+                '') config.wsl.version
+              )}
+              --json)
+                echo '${toJSON config.wsl.version}' | ${pkgs.jq}/bin/jq # Use jq to pretty-print the JSON
+                exit 0
+                ;;
+              *)
+                echo "Unknown argument: $arg"
+                exit 1
+                ;;
+            esac
+          done
+          echo NixOS-WSL ${config.wsl.version.release} ${config.wsl.version.rev} ${config.wsl.version.systemd}
+        ''
+      )
+    ];
+
+  };
+
+}

--- a/modules/version.nix
+++ b/modules/version.nix
@@ -9,16 +9,19 @@ with lib;
       in
       {
         release = mkOption {
+          internal = true;
           description = "the NixOS-WSL release";
           type = str;
           default = elemAt versionFile 0;
         };
         rev = mkOption {
+          internal = true;
           description = "the NixOS-WSL git revision";
           type = str;
           default = elemAt versionFile 1;
         };
         systemd = mkOption {
+          internal = true;
           type = enum [ "native" "syschdemd" ];
           description = "the systemd implementation used by NixOS-WSL";
           default = if config.wsl.nativeSystemd then "native" else "syschdemd";

--- a/modules/version.nix
+++ b/modules/version.nix
@@ -1,5 +1,5 @@
 { lib, pkgs, options, config, ... }:
-with builtins; with lib;
+with lib;
 {
 
   options = with types; {

--- a/modules/version.nix
+++ b/modules/version.nix
@@ -60,7 +60,7 @@ with lib;
                 '') config.wsl.version
               )}
               --json)
-                echo '${toJSON config.wsl.version}' | ${pkgs.jq}/bin/jq # Use jq to pretty-print the JSON
+                echo '${generators.toJSON {} config.wsl.version}' | ${pkgs.jq}/bin/jq # Use jq to pretty-print the JSON
                 exit 0
                 ;;
               *)


### PR DESCRIPTION
Add a `nixos-wsl-version` command. This pr also introduces a new versioning scheme to be compatible with the version format that will be required for the Distro Launcher. The format looks as follows:
```
MAJOR.MINOR.TAG.COMMIT
e.g.
22.11.4.78
```
where `MAYOR` and `MINOR` are the NixOS version, `TAG` is incremented with every NixOS-WSL release and `COMMIT` counts the commits since that release. This version is automatically calculated in the CI pipeline. If the module is imported as a flake input or the installer tarball is build locally, the version will show as `DEV_BUILD` instead.
The output of `nixos-wsl-version` contains more information besides the calculated version and looks like this:
```
NixOS-WSL 22.11.4.77 fbe364f47cb713b759865d06e4962b9930516a18 syschdemd
```
That information is additionally available in JSON format
```json
{
  "release": "22.11.4.77",
  "rev": "fbe364f47cb713b759865d06e4962b9930516a18",
  "systemd": "syschdemd"
}
```

`rev` is the git revision of NixOS-WSL and is present in CI builds as well as when importing NixOS-WSL as a flake input. When the repository has been modified locally, it will show `dirty` instead.

`systemd` shows whether native-systemd is enabled and is either `syschdemd` if it isn't or `native` if it is