### PR TITLE
Skip copying application/icons if there are none

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -88,9 +88,11 @@ with lib; {
             copy-launchers = mkIf cfg.startMenuLaunchers (
               stringAfter [ ] ''
                 for x in applications icons; do
-                  echo "Copying /usr/share/$x"
-                  mkdir -p /usr/share/$x
-                  ${pkgs.rsync}/bin/rsync -ar --delete $systemConfig/sw/share/$x/. /usr/share/$x
+                  if [ -d $systemConfig/sw/share/$x ]; then
+                    echo "Copying /usr/share/$x"
+                    mkdir -p /usr/share/$x
+                    ${pkgs.rsync}/bin/rsync -ar --delete $systemConfig/sw/share/$x/. /usr/share/$x
+                  fi
                 done
               ''
             );


### PR DESCRIPTION
In some circumstances, `$systemConfig/sw/share/icons` will not exist, causing the `copy-launchers` script to emit this error:
```
# nixos-rebuild test
building the system configuration...
activating the configuration...
Copying /usr/share/applications
Copying /usr/share/icons
rsync: [sender] change_dir "/nix/store/fmrgd368fnsn0q9y2hlli49655cbbn7q-nixos-system-stagirite-22.11.20221130.4d2b37a/sw/share/icons" failed: No such file or directory (2)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1327) [sender=3.2.6]
Activation script snippet 'copy-launchers' failed (23)
setting up /etc...
setting up /bin...
reloading user units for nixos...
setting up tmpfiles
warning: error(s) occurred while switching to the new configuration
```
This isn't caused by having no icons, since I still have `applications` when no packages place files in there. I don't know if it's a bug that `icons` doesn't exist even when it would be empty.

Output after fix, tested by overriding flake input to point to a local checkout:
```
# nixos-rebuild test
warning: Git tree '/etc/nixos' is dirty
building the system configuration...
warning: Git tree '/etc/nixos' is dirty
activating the configuration...
Copying /usr/share/applications
setting up /etc...
setting up /bin...
reloading user units for nixos...
setting up tmpfiles
```