### PR TITLE
Don't add an extra :, make robust against grep aliases

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -175,9 +175,9 @@ with lib; {
             # preserve $PATH from parent
             variables.PATH = [ "$PATH" ];
             extraInit = ''
-              export WSLPATH=$(echo "$PATH" | tr ':' '\n' | grep -E "^${cfg.wslConf.automount.root}" | tr '\n' ':')
+              export WSLPATH=$(echo "$PATH" | tr ':' '\0' | command grep -a "^${cfg.wslConf.automount.root}" | tr '\0' ':')
               ${if cfg.interop.includePath then "" else ''
-                export PATH=$(echo "$PATH" | tr ':' '\n' | grep -vE "^${cfg.wslConf.automount.root}" | tr '\n' ':')
+                export PATH=$(echo "$PATH" | tr ':' '\0' | command grep -av "^${cfg.wslConf.automount.root}" | tr '\0' ':')
               ''}
             '';
           };


### PR DESCRIPTION
grep adds a final newline which the second tr turns into an extra : By using a null byte and telling grep to treat it as text we can avoid this.

Also guard the grep against the alias in my shell :)