### PR TITLE
fix: fix compatibility with latest WSL update

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,8 @@
               side-effects = pkgs.callPackage ./checks/side-effects.nix args;
             };
 
+          packages.staticShim = pkgs.pkgsStatic.callPackage ./scripts/native-systemd-shim/shim.nix { };
+
           devShell = pkgs.mkShell {
             RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
 


### PR DESCRIPTION
The latest WSL update makes /dev/shm a mount point, not a symlink, as it should be.
Unfortunately, this does not work well with us trying to remove it. Oops.
