### PR TITLE
Only mask systemd-resolved if WSL is generating resolv.conf

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -139,7 +139,7 @@ in
             # Disable systemd units that don't make sense on WSL
             services = {
               firewall.enable = false;
-              systemd-resolved.enable = lib.mkDefault false;
+              systemd-resolved.enable = lib.mkDefault (!config.wsl.wslConf.network.generateResolvConf);
               # systemd-timesyncd actually works in WSL and without it the clock can drift
               systemd-timesyncd.unitConfig.ConditionVirtualization = "";
             };


### PR DESCRIPTION
I'm using systemd-resolved with tailscale