### PR TITLE
fix: relink the X11 socket into place if needed

### DIFF
--- a/modules/wsl-conf.nix
+++ b/modules/wsl-conf.nix
@@ -20,7 +20,7 @@ with lib; {
         description = "Mount entries from /etc/fstab through WSL. You should probably leave this on false, because systemd will mount those for you.";
       };
       root = mkOption {
-        type = str;
+        type = strMatching "^/.*[^/]$";
         default = "/mnt/";
         description = "The directory under which to mount windows drives.";
       };

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -124,6 +124,10 @@ with lib; {
 
             # Don't allow emergency mode, because we don't have a console.
             enableEmergencyMode = false;
+
+            # Link the X11 socket into place. This is a no-op on a normal setup,
+            # but helps if /tmp is a tmpfs or mounted from some other location.
+            tmpfiles.rules = [ "L /tmp/.X11-unix - - - - /mnt/wslg/.X11-unix" ];
           };
 
           # Start a systemd user session when starting a command through runuser

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -127,7 +127,7 @@ with lib; {
 
             # Link the X11 socket into place. This is a no-op on a normal setup,
             # but helps if /tmp is a tmpfs or mounted from some other location.
-            tmpfiles.rules = [ "L /tmp/.X11-unix - - - - /mnt/wslg/.X11-unix" ];
+            tmpfiles.rules = [ "L /tmp/.X11-unix - - - - ${cfg.wslConf.automount.root}/wslg/.X11-unix" ];
           };
 
           # Start a systemd user session when starting a command through runuser


### PR DESCRIPTION
Fixes X11 applications on tmp-as-tmpfs setups.