### PR TITLE
Remove wslpath from systemPackages

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -60,13 +60,6 @@ with lib; {
                 "resolv.conf".enable = false;
               })
             ];
-
-            systemPackages = [
-              (pkgs.runCommand "wslpath" { } ''
-                mkdir -p $out/bin
-                ln -s /init $out/bin/wslpath
-              '')
-            ];
           };
 
           networking.dhcpcd.enable = false;


### PR DESCRIPTION
wslpath is now always symlinked to /bin/wslpath where WSL hardcodes the path to when booting.