### PR TITLE
Add coreutils to bashWrapper

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -8,7 +8,7 @@ let
       nativeBuildInputs = [ pkgs.makeWrapper ];
     } ''
     makeWrapper ${pkgs.bashInteractive}/bin/sh $out/bin/sh \
-      --prefix PATH ':' ${lib.makeBinPath (with pkgs; [ systemd gnugrep ])}
+      --prefix PATH ':' ${lib.makeBinPath (with pkgs; [ systemd gnugrep coreutils ])}
   '';
 
   cfg = config.wsl;


### PR DESCRIPTION
VS Code needs the coreutils (to be precise, `dirname` and `uname`) to be available in `/bin/sh` when setting up the remote server.