### PR TITLE
Support CUDA in sandboxes

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -26,6 +26,7 @@ in
   nix.package = pkgs.nixFlakes;
   nix.extraOptions = ''
     experimental-features = nix-command flakes
+    extra-sandbox-paths = /usr/lib/wsl
   '';
 
   system.stateVersion = "22.11";


### PR DESCRIPTION
`/usr/lib/wsl` includes CUDA drivers. According to https://discourse.nixos.org/t/pytorch-cuda-on-wsl/18267/2 the drivers can be enabled by `export LD_LIBRARY_PATH=/usr/lib/wsl/lib`. However, without this PR, the approach only works if sandbox is not used.

This PR will enable CUDA in a sandbox, too.
