### PR TITLE
Enable udev by default (it can be useful when using usbip)

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -127,9 +127,6 @@ in
             '';
           };
 
-          # no udev devices can be attached
-          services.udev.enable = lib.mkDefault false;
-
           systemd = {
             # Disable systemd units that don't make sense on WSL
             services = {


### PR DESCRIPTION
We can support usbip with the Microsoft Store version of WSL (I think that's the one that introduced the change, also turned on WSLg)

Related is https://github.com/nix-community/NixOS-WSL/pull/175#discussion_r1048284393 which is where it got disabled, because it wasn't necessary rather than because it broke things

See https://github.com/nix-community/NixOS-WSL/issues/111 for NixOS-WSL usbip discussion