### PR TITLE
Revert "Enable udev by default (it can be useful when using usbip)"

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -127,6 +127,9 @@ in
             '';
           };
 
+          # no udev devices can be attached
+          services.udev.enable = lib.mkDefault false;
+
           systemd = {
             # Disable systemd units that don't make sense on WSL
             services = {

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -127,7 +127,7 @@ in
             '';
           };
 
-          # no udev devices can be attached
+          # useful for usbip but adds a dependency on various firmwares which are combined over 300 MB big
           services.udev.enable = lib.mkDefault false;
 
           systemd = {


### PR DESCRIPTION
Reverts nix-community/NixOS-WSL#225


Going to revert this because it draws in firmware which is 300MB big and cannot easily be disabled.

