### PR TITLE
fix: just pull in the entire environment into the /bin/sh wrapper

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -3,12 +3,9 @@
 with lib;
 
 let
-  bashWrapper = pkgs.runCommand "nixos-wsl-bash-wrapper"
-    {
-      nativeBuildInputs = [ pkgs.makeWrapper ];
-    } ''
-    makeWrapper ${pkgs.bashInteractive}/bin/sh $out/bin/sh \
-      --prefix PATH ':' ${lib.makeBinPath (with pkgs; [ systemd gnugrep ])}
+  bashWrapper = pkgs.writeShellScriptBin "sh" ''
+    . ${config.system.build.etc}/set-environment
+    exec ${pkgs.bashInteractive}/bin/sh "$@"
   '';
 
   cfg = config.wsl;


### PR DESCRIPTION
This is more consistent with what other distros do and may (MAY!) unfuck more cases of wsl -e sh -c abuse.