### PR TITLE
docker: add user to docker group.

### DIFF
--- a/modules/docker-native.nix
+++ b/modules/docker-native.nix
@@ -27,8 +27,10 @@ with builtins; with lib; {
       virtualisation.docker.package = (pkgs.docker.override { iptables = pkgs.iptables-legacy; });
       virtualisation.docker.enable = true;
 
-      users.groups.docker.members = lib.mkIf cfg.addToDockerGroup [
-        config.wsl.defaultUser
-      ];
+      users = lib.mkIf cfg.addToDockerGroup {
+        users.${config.wsl.defaultUser}.extraGroups = [
+          "docker"
+        ];
+      };
     };
 }


### PR DESCRIPTION
# Description
When using `home-manager` **sometimes** docker-native is not accessible due to user permission. 
In the official documentation it is stated that access to the docker socket is provided by adding the user to the "docker" group. 

Currently we are using `groups.docker.members`. This seems to partially work as I was able to achieve the desired outcome by using a mix of `groups.docker.members` and `users.<username>.extraGroups`.

**Note:** If you prefer I can try tomorrow to build using @nzbr 
```nix
users.extraGroups.docker.members = lib.mkIf cfg.addToDockerGroup [
          config.wsl.defaultUser
        ];
```

# Solution
Added the user to the `docker` group in the `modules/docker-native.nix` file.

# Testing
Tested locally.