### PR TITLE
fix: explicitly add systemctl and grep to path in shell-wrapper

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -4,6 +4,7 @@ with lib;
 
 let
   bashWrapper = pkgs.writeShellScriptBin "sh" ''
+    export PATH=${lib.makeBinPath [ pkgs.systemd pkgs.gnugrep ]}
     . ${config.system.build.etc}/etc/set-environment
     exec ${pkgs.bashInteractive}/bin/sh "$@"
   '';


### PR DESCRIPTION
We can generally find them in /run/current-system/sw/bin, but WSL may try to call those before activation is fully done, so make sure it can always find what it needs.