### PR TITLE
Include per-user applications in start menu launchers

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -103,11 +103,19 @@ in
               stringAfter [ ] ''
                 for x in applications icons; do
                   echo "setting up /usr/share/''${x}..."
-                  if [[ -d $systemConfig/sw/share/$x ]]; then
-                    mkdir -p /usr/share/$x
-                    ${pkgs.rsync}/bin/rsync -ar --delete $systemConfig/sw/share/$x/. /usr/share/$x
+                  targets=()
+                  if [[ -d "$systemConfig/sw/share/$x" ]]; then
+                    targets+=("$systemConfig/sw/share/$x/.")
+                  fi
+                  if [[ -d "/etc/profiles/per-user/${cfg.defaultUser}/share/$x" ]]; then
+                    targets+=("/etc/profiles/per-user/${cfg.defaultUser}/share/$x/.")
+                  fi
+
+                  if (( ''${#targets[@]} != 0 )); then
+                    mkdir -p "/usr/share/$x"
+                    ${pkgs.rsync}/bin/rsync -ar --delete-after "''${targets[@]}" "/usr/share/$x"
                   else
-                    rm -rf /usr/share/$x
+                    rm -rf "/usr/share/$x"
                   fi
                 done
               ''


### PR DESCRIPTION
I use home-manager to manage much of the software. This allows the default users applications be properly copied and thus end up on the start menu launchers.