### PR TITLE
Add usbip module for usb support in WSL

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
         imports = [
           ./modules
 
-          ({ ... }: {
+          (_: {
             wsl.version.rev = mkIf (self ? rev) self.rev;
           })
         ];

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -5,6 +5,7 @@
     ./interop.nix
     ./recovery.nix
     ./systemd
+    ./usbip.nix
     ./version.nix
     ./welcome.nix
     ./wsl-conf.nix

--- a/modules/usbip.nix
+++ b/modules/usbip.nix
@@ -1,0 +1,51 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  usbipd-win-auto-attach = pkgs.fetchurl {
+    url = "https://raw.githubusercontent.com/dorssel/usbipd-win/v3.1.0/Usbipd/wsl-scripts/auto-attach.sh";
+    hash = "sha256-KJ0tEuY+hDJbBQtJj8nSNk17FHqdpDWTpy9/DLqUFaM=";
+  };
+
+  cfg = config.wsl.usbip;
+in
+{
+  options.wsl.usbip = with types; {
+    enable = mkEnableOption "USB/IP integration";
+    autoAttach = mkOption {
+      type = listOf str;
+      default = [ ];
+      example = [ "4-1" ];
+      description = "Auto attach devices with provided Bus IDs.";
+    };
+  };
+
+  config = mkIf (config.wsl.enable && cfg.enable) {
+    environment.systemPackages = [
+      pkgs.linuxPackages.usbip
+    ];
+
+    services.udev.enable = true;
+
+    systemd = {
+      services."usbip-auto-attach@" = {
+        description = "Auto attach device having busid %i with usbip";
+        after = [ "network.target" ];
+
+        scriptArgs = "%i";
+        path = [ pkgs.linuxPackages.usbip ];
+
+        script = ''
+          busid="$1"
+          ip="$(grep nameserver /etc/resolv.conf | cut -d' ' -f2)"
+
+          echo "Starting auto attach for busid $busid on $ip."
+          source ${usbipd-win-auto-attach} "$ip" "$busid"
+        '';
+      };
+
+      targets.multi-user.wants = map (busid: "usbip-auto-attach@${busid}.service") cfg.autoAttach;
+    };
+  };
+}


### PR DESCRIPTION
This adds a module to enable USB support via usbip together with a [usbip-win](https://github.com/dorssel/usbipd-win) running on the host.

- Adds the usbip package to be able to run adhoc usbip command e.g. (usbip list --remote 172.23.96.1)
- Enables udev
- Creates systemd services to auto-attach USB devices based on busid

One caveat with accessing USB devices is that they will require wider permissions than that will most likely be configured. For example the infrastructure provided by NixOS to enable YubiKeys will add a rule with permission mode `0660`. While when running WSL with usbip you need to set `0666` in the udev rules.

So for example to get YubiKeys working you would need something like this:
```nix
{
  services = {
    pcscd.enable = true;
    udev = {
      packages = [pkgs.yubikey-personalization];
      extraRules = lib.optionalString config.wsl.usbip.enable ''
        SUBSYSTEM=="usb", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0116|0401|0403|0405|0407|0410", MODE="0666"
      '';
    };
  };
}
```

If we look into the udev rule provided by the `yubikey-personalization` package it looks like this:
```
$ nix build nixpkgs#yubikey-personalization
$ cat result/lib/udev/rules.d/69-yubikey.rules
ACTION!="add|change", GOTO="yubico_end"

# Udev rules for letting the console user access the Yubikey USB
# device node, needed for challenge/response to work correctly.

# Yubico Yubikey II
ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0010|0110|0111|0114|0116|0401|0403|0405|0407|0410", \
    ENV{ID_SECURITY_TOKEN}="1"

LABEL="yubico_end"
```

I don't know enough about udev rules, but would it be possible to do something generic like this:
```
SUBSYSTEM=="usb", MODE="0666"
```

Any ideas appreciated. At least with this configuration I have YubiKey's working within WSL with auto-attach, so I just plug in/unplug and can use it like I would regularly expect on a normal Linux device.