### PR TITLE
fix: getent missing in syschdemd

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686929285,
-        "narHash": "sha256-WGtVzn+vGMPTXDO0DMNKVFtf+zUSqeW+KKk4Y/Ae99I=",
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "93fddcf640ceca0be331210ba3101cee9d91c13d",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
         "type": "github"
       },
       "original": {

--- a/scripts/syschdemd.nix
+++ b/scripts/syschdemd.nix
@@ -3,7 +3,7 @@
 , lib
 , coreutils
 , daemonize
-, glibc
+, getent
 , gnugrep
 , systemd
 , util-linux
@@ -43,7 +43,7 @@ mkWrappedScript {
     "/run/wrappers" # mount
     coreutils
     daemonize
-    glibc # getent
+    getent
     gnugrep
     systemd # machinectl
     util-linux # nsenter, runuser


### PR DESCRIPTION
Related to the discussion in #237 (though it doesn't address the original issue, so don't close that after merging this)

`getent` was moved to its own derivation and removed from `glibc` on unstable. Therefore syschdemd crashed on systems running nixos-unstable. By using the getent derivation instead, it works on 22.11, 23.05 and unstable (that's the ones I tested, it might work on older versions as well)