### PR TITLE
Add a workaround to support VS Code's Remote WSL extension (fix #238)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,22 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -34,7 +50,62 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-ld-rs": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1692825040,
+        "narHash": "sha256-01V6wiLzXe2acXPriiHnn/MMQpwYXcneC0tIqbdcny8=",
+        "owner": "nix-community",
+        "repo": "nix-ld-rs",
+        "rev": "35987e7f70ca6845489e8abc6e7897775c01a5c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-ld-rs",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1692638711,
+        "narHash": "sha256-J0LgSFgJVGCC1+j5R2QndadWI1oumusg6hCtYAzLID4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "91a22f76cd1716f9d0149e8a5c68424bb691de15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1697851979,
         "narHash": "sha256-lJ8k4qkkwdvi+t/Xc6Fn74kUuobpu9ynPGxNZR6OwoA=",
@@ -54,10 +125,51 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nix-ld-rs": "nix-ld-rs",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "nix-ld-rs",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nix-ld-rs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1692756590,
+        "narHash": "sha256-VnktafFl+0U9wdYO8vGSFOYSSQ+GFd+MiMA0cTZ8mHg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a9e9946645fcf892c850f8e654a5e675a6fd14d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
+    nix-ld-rs.url = "github:nix-community/nix-ld-rs";
 
     flake-compat = {
       url = "github:edolstra/flake-compat";
@@ -11,7 +12,7 @@
     };
   };
 
-  outputs = inputs@{ self, nixpkgs, flake-utils, ... }:
+  outputs = inputs@{ self, nixpkgs, flake-utils, nix-ld-rs, ... }:
     with nixpkgs.lib;
     {
 
@@ -21,6 +22,7 @@
 
           ({ ... }: {
             wsl.version.rev = mkIf (self ? rev) self.rev;
+            wsl.vscodeRemoteWslExtensionWorkaround.nix-ld-rs = nix-ld-rs;
           })
         ];
       };

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -9,6 +9,7 @@
     ./welcome.nix
     ./wsl-conf.nix
     ./wsl-distro.nix
+    ./vscode-remote-wsl-extension-workaround.nix
 
     (lib.mkRemovedOptionModule [ "wsl" "docker-native" ]
       "Additional workarounds are no longer required for Docker to work. Please use the standard `virtualisation.docker` NixOS options.")

--- a/modules/vscode-remote-wsl-extension-workaround.nix
+++ b/modules/vscode-remote-wsl-extension-workaround.nix
@@ -1,0 +1,37 @@
+{ lib, config, pkgs, ... }:
+{
+  options.wsl.vscodeRemoteWslExtensionWorkaround = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Workaround for VSCode's Remote WSL extension";
+    };
+    nix-ld-rs = lib.mkOption {
+      type = lib.types.raw;
+      description = "The flake input to use for `nix-ld-rs`";
+    };
+  };
+
+  config =
+    let
+      cfg = config.wsl.vscodeRemoteWslExtensionWorkaround;
+    in
+    lib.mkIf cfg.enable {
+      wsl.extraBin = [
+        # Required by VS Code's Remote WSL extension
+        { src = "${pkgs.coreutils}/bin/dirname"; }
+        { src = "${pkgs.coreutils}/bin/readlink"; }
+        { src = "${pkgs.coreutils}/bin/uname"; }
+      ];
+      programs.nix-ld = {
+        enable = true;
+        libraries = [
+          # Required by NodeJS installed by VS Code's Remote WSL extension
+          pkgs.stdenv.cc.cc
+        ];
+
+        # Use `nix-ld-rs` instead of `nix-ld`, because VS Code's Remote WSL extension launches a non-login non-interactive shell, which is not supported by `nix-ld`, while `nix-ld-rs` works in non-login non-interactive shells.
+        package = cfg.nix-ld-rs.packages.${pkgs.system}.nix-ld-rs;
+      };
+    };
+}


### PR DESCRIPTION
This PR adds `modules/vscode-remote-wsl-extension-workaround.nix`, when `wsl.vscodeRemoteWslExtensionWorkaround.enable` is `true`, VS Code's Remote WSL extension can connect to NixOS, fixing #238

See https://github.com/Atry/nixos-wsl-vscode/blob/main/flake.nix for usage