### PR TITLE
wsl-distro: introduce `wsl.useWindowsDriver` option

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -9,6 +9,7 @@ in
 
   options.wsl = with types; {
     enable = mkEnableOption "support for running NixOS as a WSL distribution";
+    useWindowsDriver = mkEnableOption "OpenGL driver from the Windows host";
     binShPkg = mkOption {
       type = package;
       internal = true;
@@ -70,7 +71,16 @@ in
     # WSL does not support virtual consoles
     console.enable = false;
 
-    hardware.opengl.enable = true; # Enable GPU acceleration
+    hardware.opengl = {
+      enable = true; # Enable GPU acceleration
+
+      extraPackages = mkIf cfg.useWindowsDriver [
+        (pkgs.runCommand "wsl-lib" { } ''
+          mkdir "$out"
+          ln -s /usr/lib/wsl/lib "$out/lib"
+        '')
+      ];
+    };
 
     environment = {
       # Only set the options if the files are managed by WSL


### PR DESCRIPTION
This PR introduce `wsl.useWindowsDriver` option, which enables `/usr/lib/wsl/lib` as OpenGL driver.

With the help of this PR, CUDA can be used if there is a Nvidia GPU.

```
[nixos@nixos:~]$ nvidia-smi
Thu Nov 16 05:46:07 2023       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 545.23.05              Driver Version: 545.84       CUDA Version: 12.3     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA GeForce RTX 3060        On  | 00000000:07:00.0  On |                  N/A |
|  0%   38C    P8              18W / 170W |   1481MiB / 12288MiB |      2%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
                                                                                         
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A        25      G   /Xwayland                                 N/A      |
+---------------------------------------------------------------------------------------+
```