### PR TITLE
Disable bootspec

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -59,6 +59,7 @@ in
   config = mkIf cfg.enable {
     # WSL uses its own kernel and boot loader
     boot = {
+      bootspec.enable = false;
       initrd.enable = false;
       kernel.enable = false;
       loader.grub.enable = false;


### PR DESCRIPTION
which holds a reference to the kernel

On my system this results in the following change:

```
System package diff:
linux: 6.6.7 → ∅, -128630.1 KiB
```