### PR TITLE
Improve WSLg desktop integration

### DIFF
--- a/modules/systemd/default.nix
+++ b/modules/systemd/default.nix
@@ -41,6 +41,14 @@ with lib; {
         # Link the X11 socket into place. This is a no-op on a normal setup,
         # but helps if /tmp is a tmpfs or mounted from some other location.
         tmpfiles.rules = [ "L /tmp/.X11-unix - - - - ${cfg.wslConf.automount.root}/wslg/.X11-unix" ];
+
+        # Link *.desktop files and icons where WSLg expects them so that GUI apps show up in Start menu
+        tmpfiles.settings.wslg_integration = {
+          "/usr/share/applications".L.argument =
+            "/etc/profiles/per-user/${cfg.defaultUser}/share/applications";
+          "/usr/share/icons".L.argument =
+            "/etc/profiles/per-user/${cfg.defaultUser}/share/icons";
+        };
       };
 
     };

--- a/modules/systemd/default.nix
+++ b/modules/systemd/default.nix
@@ -44,10 +44,8 @@ with lib; {
 
         # Link *.desktop files and icons where WSLg expects them so that GUI apps show up in Start menu
         tmpfiles.settings.wslg_integration = {
-          "/usr/share/applications".L.argument =
-            "/etc/profiles/per-user/${cfg.defaultUser}/share/applications";
-          "/usr/share/icons".L.argument =
-            "/etc/profiles/per-user/${cfg.defaultUser}/share/icons";
+          "/usr/share/applications".L.argument = "/etc/profiles/per-user/${cfg.defaultUser}/share/applications";
+          "/usr/share/icons".L.argument = "/etc/profiles/per-user/${cfg.defaultUser}/share/icons";
         };
       };
 


### PR DESCRIPTION
The problem is that the WSLg layer looks up the *.desktop files in these folders:

* /usr/share/applications
* /usr/local/share/applications
* /var/lib/snapd/desktop/applications
* /var/lib/flatpak/exports/share/applications

None of which exists in NixOS by default.

This adds a symlink to per-user profile for the default WSL user. With the symlinks in place WSLg can find *.desktop files and show up GUI apps in Windows Start menu.

Symlinking icons also makes sure correct icons appear for the Start menu entries and running apps.

This resolves https://github.com/nix-community/NixOS-WSL/issues/362

Note that AFAIK the WSLg applications folder discovery happens just after start of the WSL distribution, so this might require WSL restart after this has been applied for WSLg to pick up the folders/apps.