### PR TITLE
Fix symlink creation of per-user apps/icons folder

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -109,8 +109,8 @@ in
             if [[ -d "$systemConfig/sw/share/$x" ]]; then
               targets+=("$systemConfig/sw/share/$x/.")
             fi
-            if [[ -d "/etc/profiles/per-user/${cfg.defaultUser}/share/$x" ]]; then
-              targets+=("/etc/profiles/per-user/${cfg.defaultUser}/share/$x/.")
+            if [[ -d "/etc/profiles/per-user/${config.users.users.${cfg.defaultUser}.name}/share/$x" ]]; then
+              targets+=("/etc/profiles/per-user/${config.users.users.${cfg.defaultUser}.name}/share/$x/.")
             fi
 
             if (( ''${#targets[@]} != 0 )); then


### PR DESCRIPTION
Closes #362

The code relied on `defaultUser` attribute name in `config.users.users` to be the same as the username. This is not always the case as the username can be set by `name` attribute inside the user configuration

So for following user

```nix
users.users.foo.name = "bar";
```

the `wsl.defaultUser = "foo"` works, but the `wsl.startMenuLaunchers = true` won't work because it tries to find applications folder at `/etc/profiles/per-user/foo/share` rather than
`/etc/profiles/per-user/bar/share` that is actually created.

This PR uses the `name` attribute of that user instead which should fix the issue. (tested locally, it seems to be working correctly)