### PR TITLE
feat: add option to disable wslg x11 mount

### DIFF
--- a/modules/systemd/default.nix
+++ b/modules/systemd/default.nix
@@ -12,6 +12,11 @@ with lib; {
       default = true;
       description = "Use native WSL systemd support";
     };
+    wslgMountX11 = mkOption {
+      type = bool;
+      default = true;
+      description = "Mount the WSLg .X11-unix directory into /tmp";
+    };
   };
 
   config =
@@ -40,7 +45,7 @@ with lib; {
 
         # Link the X11 socket into place. This is a no-op on a normal setup,
         # but helps if /tmp is a tmpfs or mounted from some other location.
-        tmpfiles.rules = [ "L /tmp/.X11-unix - - - - ${cfg.wslConf.automount.root}/wslg/.X11-unix" ];
+        tmpfiles.rules = mkIf cfg.wslgMountX11 ([ "L /tmp/.X11-unix - - - - ${cfg.wslConf.automount.root}/wslg/.X11-unix" ]);
       };
 
     };

--- a/modules/systemd/default.nix
+++ b/modules/systemd/default.nix
@@ -12,11 +12,6 @@ with lib; {
       default = true;
       description = "Use native WSL systemd support";
     };
-    wslgMountX11 = mkOption {
-      type = bool;
-      default = true;
-      description = "Mount the WSLg .X11-unix directory into /tmp";
-    };
   };
 
   config =
@@ -45,9 +40,15 @@ with lib; {
 
         # Link the X11 socket into place. This is a no-op on a normal setup,
         # but helps if /tmp is a tmpfs or mounted from some other location.
-        tmpfiles.rules = mkIf cfg.wslgMountX11 ([ "L /tmp/.X11-unix - - - - ${cfg.wslConf.automount.root}/wslg/.X11-unix" ]);
+        tmpfiles.settings = {
+          "10-wslg-x11" = {
+            "/tmp/.X11-unix" = {
+              L = {
+                argument = "${cfg.wslConf.automount.root}/wslg/.X11-unix";
+              };
+            };
+          };
+        };
       };
-
     };
-
 }


### PR DESCRIPTION
This PR migrates from `systemd.tmpfiles.rules` to `systemd.tmpfiles.settings` to allow user overrides.

This way the `/tmp/.X11-unix` wslg mount can be disabled with:

```nix
systemd.tmpfiles.settings = {
  "10-wslg-x11" = lib.mkForce {};
};
```

For reference the old and new content in `/etc/tmpfiles.d`:

old: `L /tmp/.X11-unix - - - - /mnt/wslg/.X11-unix`
new: `'L' '/tmp/.X11-unix' '-' '-' '-' '-' /mnt/wslg/.X11-unix`