### PR TITLE
fix: start menu launchers rsync of directory symlinks

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -125,7 +125,7 @@ in
 
             if (( ''${#targets[@]} != 0 )); then
               mkdir -p "/usr/share/$x"
-              ${pkgs.rsync}/bin/rsync -ar --copy-dirlinks --delete-after "''${targets[@]}" "/usr/share/$x"
+              ${pkgs.rsync}/bin/rsync --archive --copy-dirlinks --delete-after --recursive "''${targets[@]}" "/usr/share/$x"
             else
               rm -rf "/usr/share/$x"
             fi

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -125,7 +125,7 @@ in
 
             if (( ''${#targets[@]} != 0 )); then
               mkdir -p "/usr/share/$x"
-              ${pkgs.rsync}/bin/rsync -ar --delete-after "''${targets[@]}" "/usr/share/$x"
+              ${pkgs.rsync}/bin/rsync -ar --copy-dirlinks --delete-after "''${targets[@]}" "/usr/share/$x"
             else
               rm -rf "/usr/share/$x"
             fi


### PR DESCRIPTION
When using a profile containing icons having a symlink such as:
```
/etc/profiles/per-user/USER/share/icons/hicolor -> /nix/store/fvlvfdkc9hh7icadwqxfiazifmsxprrl-home-manager-path/share/icons/hicolor
```

The merge of several rsync sources doesn't work properly. With this fix it will copy the symlinked directory instead and in that way support the rsync.