### PR TITLE
Ask for output of wsl --version, remove expected behavior

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,12 +15,16 @@ assignees: ''
 ## To Reproduce
 Steps to reproduce the behavior:
 
-**Expected behavior**
-<!-- A clear and concise description of what you expected to happen. -->
-
 ## Logs
 ```
 Include relevant console logs
+```
+
+## WSL version
+<!-- Only WSL 2 version 2.0.0 or newer is supported -->
+
+```
+Please paste zhe output of wsl --version here
 ```
 
 <!-- If your issue is related to the installation process, please include the SHA256 checksum of the tarball you used to install NixOS-WSL -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ Include relevant console logs
 <!-- Only WSL 2 version 2.0.0 or newer is supported -->
 
 ```
-Please paste zhe output of wsl --version here
+Please paste the output of wsl --version here
 ```
 
 <!-- If your issue is related to the installation process, please include the SHA256 checksum of the tarball you used to install NixOS-WSL -->


### PR DESCRIPTION
We are asking wsl --version in every issue anyway.

Expected behavior is often literally that what under big description is described should work or for the lazy ones ``it should work`` which we can safe.