### PR TITLE
fix: set state version when building tarballs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
 
             programs.bash.loginShellInit = "nixos-wsl-welcome";
 
-            system.stateVersion = "${config.system.nixos.release}";
+            system.stateVersion = config.system.nixos.release;
           };
         in
         {

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
 
       nixosConfigurations =
         let
-          initialConfig = {
+          initialConfig = { config, ... }: {
             wsl.enable = true;
 
             programs.bash.loginShellInit = "nixos-wsl-welcome";

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,8 @@
             wsl.enable = true;
 
             programs.bash.loginShellInit = "nixos-wsl-welcome";
+
+            system.stateVersion = "${config.system.nixos.release}";
           };
         in
         {

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,8 @@
                     mkdir -p /bin
                     ln -sfn ${syschdemdProxy} /bin/syschdemd
                   '';
+
+                system.stateVersion = "${config.system.nixos.release}";
               })
             ];
           };

--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
                     ln -sfn ${syschdemdProxy} /bin/syschdemd
                   '';
 
-                system.stateVersion = "${config.system.nixos.release}";
+                system.stateVersion = config.system.nixos.release;
               })
             ];
           };


### PR DESCRIPTION
Removes the warning about `system.stateVersion` not being set when building tarballs with the configurations provided in `flake.nix`