### PR TITLE
fix: bind mount X11 socket instead of symlinking

### DIFF
--- a/modules/systemd/default.nix
+++ b/modules/systemd/default.nix
@@ -37,18 +37,7 @@ with lib; {
 
         # Don't allow emergency mode, because we don't have a console.
         enableEmergencyMode = false;
-
-        # Link the X11 socket into place. This is a no-op on a normal setup,
-        # but helps if /tmp is a tmpfs or mounted from some other location.
-        tmpfiles.settings = {
-          "10-wslg-x11" = {
-            "/tmp/.X11-unix" = {
-              L = {
-                argument = "${cfg.wslConf.automount.root}/wslg/.X11-unix";
-              };
-            };
-          };
-        };
       };
+
     };
 }

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -112,6 +112,12 @@ in
       ];
     };
 
+    # Make sure the WSLg X11 socket is available if /tmp is mounted to something else
+    fileSystems."/tmp/.X11-unix/X0" = {
+      device = "${cfg.wslConf.automount.root}/wslg/.X11-unix/X0";
+      options = [ "bind" ];
+    };
+
     # dhcp is handled by windows
     networking.dhcpcd.enable = false;
 


### PR DESCRIPTION
Fixes #328 
Bind mount the X0 socket instead of symlinking `/tmp/.X11-unix` to make FHS environments work