### PR TITLE
Enable tests on Windows

### DIFF
--- a/.github/workflows/run_build.yml
+++ b/.github/workflows/run_build.yml
@@ -12,7 +12,8 @@ jobs:
         config:
           - modern
           - legacy
-          - test
+          - test-docker
+          - test-windows
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -33,7 +33,7 @@ jobs:
         test: ${{ fromJSON(needs.prepare.outputs.tests) }}
         os:
           - ubuntu-20.04
-          # - windows-latest # doesn't work due to lack of nested virtualization on the runners, hopefully this will work one day
+          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -44,7 +44,14 @@ jobs:
       - name: Download Tarball 📥
         uses: actions/download-artifact@v4
         with:
-          name: tarball-test
+          name: ${{ runner.os == 'Windows' && 'tarball-test-windows' || 'tarball-test-docker' }}
+
+      - name: Update WSL to enable support of WSL2
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          wsl --update
+          wsl --version
 
       - name: Execute Test 🧪
         shell: pwsh

--- a/tests/lib/lib.ps1
+++ b/tests/lib/lib.ps1
@@ -129,7 +129,7 @@ class WslDistro : Distro {
     if ($LASTEXITCODE -ne 0) {
       throw "Failed to import distro"
     }
-    & wsl.exe --list | Should -Contain $this.id
+    & wsl.exe --list -q | Should -Contain $this.id
 
     $this.Launch("sudo nix-channel --update")
   }
@@ -137,7 +137,10 @@ class WslDistro : Distro {
   [Array]Launch([string]$command) {
     Write-Host "> $command"
     $result = @()
-    & wsl.exe -d $this.id -e /bin/syschdemd -c $command | Tee-Object -Variable result | Write-Host
+    # Must explicitly use `bash -l` because otherwise WSL does not source /etc/profile.
+    # Interestingly, it works when using the interactive `wsl -d <distro>` without further arguments.
+    # Might be related: https://github.com/microsoft/WSL/issues/11152
+    & wsl.exe -d $this.id -e /run/current-system/sw/bin/bash -lc $command | Tee-Object -Variable result | Write-Host
     return $result | Remove-Escapes
   }
 


### PR DESCRIPTION
GitHub recently upgraded their free-tier runners (Standard GitHub-hosted runners).
https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/

The new VMs support nested virtualization, although it is not documented in the blog post. This draft enables the tests on Windows, but not all of them are working.

 1. `sudo nixos-rebuild switch` seems to hang in various tests for some reason.
 2. `docker/docker.Tests.ps1` fails. Here are the first two statements from the output:
    ```
    invalid pointererror: builder for '/nix/store/pq20h6rhjkndrl1x4d7rm63ahl62hb6j-nixos-23.11.drv' failed due to signal 11 (Segmentation fault)
    error: program '/nix/store/vgncjxxj6vfzynnh0si7c67466m1sm37-nix-2.18.1/bin/nix-env' failed with exit code 100
    ```

See also [my last run](https://github.com/JojOatXGME/NixOS-WSL/actions/runs/8093227763). I don't really have time to figure out how to fix it. Anyway, I thought you might still be interested to know.