### PR TITLE
Update README.md - use %localappdata% instead of the cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Modules for running NixOS on the Windows Subsystem for Linux
 2. Import the tarball into WSL:
 
 - ```powershell
-  wsl --import NixOS %localappdata%\NixOS\ nixos-wsl.tar.gz
+  wsl --import NixOS %userprofile%\NixOS\ nixos-wsl.tar.gz
   ```
 
 3. You can now run NixOS:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Modules for running NixOS on the Windows Subsystem for Linux
 2. Import the tarball into WSL:
 
 - ```powershell
-  wsl --import NixOS .\NixOS\ nixos-wsl.tar.gz --version 2
+  wsl --import NixOS %localappdata%\NixOS\ nixos-wsl.tar.gz
   ```
 
 3. You can now run NixOS:

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -12,7 +12,7 @@ First, [download the latest release](https://github.com/nix-community/NixOS-WSL/
 Then open up a Terminal, PowerShell or Command Prompt and run:
 
 ```powershell
-wsl --import NixOS .\NixOS\ nixos-wsl.tar.gz --version 2
+wsl --import NixOS %userprofile%\NixOS\ nixos-wsl.tar.gz
 ```
 
 This sets up a new WSL distribution `NixOS` that is installed under


### PR DESCRIPTION
Hi,

I first installed NixOS-WSL according to the instructions in the README.md, and it created a NixOS folder in my Downloads folder, in which the filesystem was stored. I saw that the other WSL filesystems are located in %localappdata% (AppData\Local), so this seems like a much better instruction to give in the README file.

Also, the README include adding `--version 2`. It works, but I don't think it does anything. `wsl --help` shows that `--version` just displays the version. I checked, and the command works without the `--version 2` arguments just as well.