### PR TITLE
usbip: make more reliable by using default route

### DIFF
--- a/modules/usbip.nix
+++ b/modules/usbip.nix
@@ -34,11 +34,14 @@ in
         after = [ "network.target" ];
 
         scriptArgs = "%i";
-        path = [ pkgs.linuxPackages.usbip ];
+        path = with pkgs; [
+          iproute2
+          linuxPackages.usbip
+        ];
 
         script = ''
           busid="$1"
-          ip="$(grep nameserver /etc/resolv.conf | cut -d' ' -f2)"
+          ip="$(ip route list | sed -nE 's/(default)? via (.*) dev eth0 proto kernel/\2/p')"
 
           echo "Starting auto attach for busid $busid on $ip."
           source ${usbipd-win-auto-attach} "$ip" "$busid"

--- a/modules/usbip.nix
+++ b/modules/usbip.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   usbipd-win-auto-attach = pkgs.fetchurl {
     url = "https://raw.githubusercontent.com/dorssel/usbipd-win/v3.1.0/Usbipd/wsl-scripts/auto-attach.sh";
@@ -11,17 +9,17 @@ let
   cfg = config.wsl.usbip;
 in
 {
-  options.wsl.usbip = with types; {
-    enable = mkEnableOption "USB/IP integration";
-    autoAttach = mkOption {
-      type = listOf str;
+  options.wsl.usbip = {
+    enable = lib.mkEnableOption "USB/IP integration";
+    autoAttach = lib.mkOption {
+      type = with lib.types; listOf str;
       default = [ ];
       example = [ "4-1" ];
       description = "Auto attach devices with provided Bus IDs.";
     };
   };
 
-  config = mkIf (config.wsl.enable && cfg.enable) {
+  config = lib.mkIf (config.wsl.enable && cfg.enable) {
     environment.systemPackages = [
       pkgs.linuxPackages.usbip
     ];

--- a/modules/usbip.nix
+++ b/modules/usbip.nix
@@ -11,11 +11,22 @@ in
 {
   options.wsl.usbip = {
     enable = lib.mkEnableOption "USB/IP integration";
+
     autoAttach = lib.mkOption {
       type = with lib.types; listOf str;
       default = [ ];
       example = [ "4-1" ];
       description = "Auto attach devices with provided Bus IDs.";
+    };
+
+    snippetIpAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "$(ip route list | sed -nE 's/(default)? via (.*) dev eth0 proto kernel/\2/p')";
+      example = "127.0.0.1";
+      description = ''
+        This snippet is used to obtain the address of the Windows host where Usbipd is running.
+        It can also be a plain IP address in case networkingMode=mirrored or wsl-vpnkit is used.
+      '';
     };
   };
 
@@ -39,7 +50,7 @@ in
 
         script = ''
           busid="$1"
-          ip="$(ip route list | sed -nE 's/(default)? via (.*) dev eth0 proto kernel/\2/p')"
+          ip="${cfg.snippetIpAddress}"
 
           echo "Starting auto attach for busid $busid on $ip."
           source ${usbipd-win-auto-attach} "$ip" "$busid"


### PR DESCRIPTION
The nameserver does not necessarily need to be the windows host.

/cc @terlar 