### PR TITLE
fix: prevent systemd from hiding wayland socket

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -135,6 +135,12 @@ in
       };
     };
 
+    # Prevent systemd from mounting a tmpfs over the runtime dir (and thus hiding the wayland socket)
+    systemd.services."user-runtime-dir@" = {
+      overrideStrategy = "asDropin";
+      unitConfig.ConditionPathExists = "!/run/user/%i";
+    };
+
     # dhcp is handled by windows
     networking.dhcpcd.enable = false;
 


### PR DESCRIPTION
Fixes #448

A recent change in an upstream package makes systemd mount a `tmpfs` over `/run/user/<id>` when a user session is started. This leads to the wayland-socket to which WSL puts a symlink to into this directory, no longer being accessible.
This is fixed here by making the relevant unit no longer run if the directory is already present