### PR TITLE
Add instructions to enable WSL 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Modules for running NixOS on the Windows Subsystem for Linux
 
 ## Quick Start
 
-1. Enable WSL if you haven’t done so:
+1. Enable WSL if you haven't done already:
 
   - ```powershell
     wsl --install --no-distribution

--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@ Modules for running NixOS on the Windows Subsystem for Linux
 
 ## Quick Start
 
-1. Download `nixos-wsl.tar.gz` from [the latest release](https://github.com/nix-community/NixOS-WSL/releases/latest).
+0. Enable WSL if you haven’t done so:
 
-2. Import the tarball into WSL:
+  - ```powershell
+    wsl --install --no-distribution
+    ```
+
+2. Download `nixos-wsl.tar.gz` from [the latest release](https://github.com/nix-community/NixOS-WSL/releases/latest).
+
+3. Import the tarball into WSL:
 
 - ```powershell
   wsl --import NixOS $env:USERPROFILE\NixOS\ nixos-wsl.tar.gz

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Modules for running NixOS on the Windows Subsystem for Linux
 
 ## Quick Start
 
-0. Enable WSL if you haven’t done so:
+1. Enable WSL if you haven’t done so:
 
   - ```powershell
     wsl --install --no-distribution
@@ -25,7 +25,7 @@ Modules for running NixOS on the Windows Subsystem for Linux
   wsl --import NixOS $env:USERPROFILE\NixOS\ nixos-wsl.tar.gz
   ```
 
-3. You can now run NixOS:
+4. You can now run NixOS:
 
 - ```powershell
   wsl -d NixOS


### PR DESCRIPTION
I've recently tried to install NixOS on a fresh installation of Windows 11. I couldn't import tarball until I install WSL either with another distro or no distro. `wsl.exe` doesn't even print `--import` as an option until it's done.