### PR TITLE
fix: set wsl.useWindowsDriver when the nvidia-ctk is enabled

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -3,6 +3,7 @@
     ./build-tarball.nix
     ./docker-desktop.nix
     ./interop.nix
+    ./nvidia.nix
     ./recovery.nix
     ./systemd
     ./usbip.nix

--- a/modules/nvidia.nix
+++ b/modules/nvidia.nix
@@ -1,0 +1,24 @@
+{ config, lib, ... }:
+{
+
+  config =
+    lib.mkIf
+      (
+        config.wsl.enable &&
+        (config.wsl.docker-desktop.enable ||
+        config.virtualisation.podman.enable ||
+        (config.virtualisation.docker.enable &&
+        (lib.versionAtLeast config.virtualisation.docker.package.version "25")))
+      )
+      {
+
+        # Related issues:
+        #   - https://github.com/nix-community/NixOS-WSL/issues/433
+        #   - https://github.com/NVIDIA/nvidia-container-toolkit/issues/452
+        #
+        # By setting `useWindowsDriver` to true, the Nvidia libraries are properly
+        # mounted on the container from the host.
+        wsl.useWindowsDriver = lib.mkIf config.hardware.nvidia-container-toolkit.enable true;
+
+      };
+}


### PR DESCRIPTION
This improves the user experience as whenever the user enables the `config.hardware.nvidia-container-toolkit.enable` option, they cannot use their Nvidia GPU's within the Docker containers because of missing libraries.

This gets fixed by setting `wsl.useWindowsDriver` explicitly when the user requests to enable GPU support on Docker containers.

Issue and fix provided by @qwqawawow

Related: https://github.com/nix-community/NixOS-WSL/issues/433
Related: https://github.com/NVIDIA/nvidia-container-toolkit/issues/452

---

Note: unsure if this is the right approach for this project. I am the maintainer of the CDI-generation for NixOS, and we got a couple of reports that users could not use their GPU's inside Docker containers.

I cannot test it since I don't use NixOS-WSL, but I thought it would be good to improve the user experience here a bit if possible.

Thanks :)