### PR TITLE
fix: prevent leaking home when building without sandbox

### DIFF
--- a/utils/default.nix
+++ b/utils/default.nix
@@ -6,6 +6,10 @@ rustPlatform.buildRustPackage {
   src = ./.;
   cargoLock.lockFile = ./Cargo.lock;
 
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
   env = {
     NIXOS_WSL_SH = "${bash}/bin/sh";
     NIXOS_WSL_ENV = "${coreutils}/bin/env";


### PR DESCRIPTION
Multiple times when I tried to get my WSL image build working on a self-hosted GitHub Action running in a rootless docker container. I ended up with the super annoying message and failure:
```
error: home directory '/homeless-shelter' exists; please remove it to assure purity of builds without sandboxing
```

It was quite hard to pin-point where this came from, but I managed to reproduce it and saw that in this environment `/homeless-shelter` was writable and thus this derivation ended up writing some of it's cargo cache to there. When I set the `HOME` variable like this, the issue disappears and I am finally able to build my configuration.