### PR TITLE
Resolve renamed option hardware.opengl -> hardware.graphics

### DIFF
--- a/modules/24.05-compat.nix
+++ b/modules/24.05-compat.nix
@@ -1,0 +1,9 @@
+{ lib, ... }: {
+  # Copied from https://github.com/NixOS/nixos-hardware/blob/master/common/gpu/24.05-compat.nix
+
+  # Backward-compat for 24.05, can be removed after we drop 24.05 support
+  imports = lib.optionals (lib.versionOlder lib.version "24.11pre") [
+    (lib.mkAliasOptionModule [ "hardware" "graphics" "enable" ] [ "hardware" "opengl" "enable" ])
+    (lib.mkAliasOptionModule [ "hardware" "graphics" "extraPackages" ] [ "hardware" "opengl" "extraPackages" ])
+  ];
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,5 +1,9 @@
 { lib, ... }: {
   imports = [
+    # required for options from 24.11 to work on 24.05
+    # TODO: remove when 24.11 becomes stable
+    ./24.05-compat.nix
+
     ./build-tarball.nix
     ./docker-desktop.nix
     ./interop.nix

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -71,7 +71,7 @@ in
     # WSL does not support virtual consoles
     console.enable = false;
 
-    hardware.opengl = {
+    hardware.graphics = {
       enable = true; # Enable GPU acceleration
 
       extraPackages = mkIf cfg.useWindowsDriver [


### PR DESCRIPTION
As of https://github.com/NixOS/nixpkgs/pull/320228, `hardware.opengl` was renamed to `hardware.graphics`, causing definitions of the former to trigger an evaluation warning on the current nixos-unstable channel. Aliases are applied conditionally for these new options to continue supporting 24.05

edit: fixes #498