### PR TITLE
nixpkgs has changed hardware.opengl to hardware.graphics

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -71,7 +71,7 @@ in
     # WSL does not support virtual consoles
     console.enable = false;
 
-    hardware.opengl = {
+    hardware.graphics = {
       enable = true; # Enable GPU acceleration
 
       extraPackages = mkIf cfg.useWindowsDriver [


### PR DESCRIPTION
NixOS / nixpkgs [treewide: big opengl cleanup](https://github.com/NixOS/nixpkgs/commit/98cef4c27326d0f9e521654441929c1c7c64f8e9)