### PR TITLE
usbip: fix default snippetIpAddress command

### DIFF
--- a/modules/usbip.nix
+++ b/modules/usbip.nix
@@ -38,9 +38,14 @@ in
     services.udev.enable = true;
 
     systemd = {
+      targets.usbip = {
+        description = "USBIP";
+      };
+
       services."usbip-auto-attach@" = {
         description = "Auto attach device having busid %i with usbip";
         after = [ "network.target" ];
+        partOf = [ "usbip.target" ];
 
         scriptArgs = "%i";
         path = with pkgs; [

--- a/modules/usbip.nix
+++ b/modules/usbip.nix
@@ -21,7 +21,7 @@ in
 
     snippetIpAddress = lib.mkOption {
       type = lib.types.str;
-      default = "$(ip route list | sed -nE 's/(default)? via (.*) dev eth0 proto kernel/\2/p')";
+      default = "$(ip route list | sed -nE 's/(default)? via (.*) dev eth0 .*/\\2/p' | head -n1)";
       example = "127.0.0.1";
       description = ''
         This snippet is used to obtain the address of the Windows host where Usbipd is running.


### PR DESCRIPTION
This fixes some bugs that I discovered in the default command.

The nix string escaping was wrong so the `\` got lost and when I tested this the command had a trailing space that made it fail still.

Also this didn't work when I was using network-mode mirrored since it includes metric in the output:

```
$ ip route list
default via 192.168.1.1 dev eth0 proto kernel metric 35
192.168.1.0/24 dev eth0 proto kernel scope link metric 291
192.168.1.1 dev eth0 proto kernel scope link metric 35
```

This also adds a target so you can batch restart the services. This is handy when having multiple YubiKeys and or switching between VPN. Perhaps there could even be some auto-restart thing. Will have to think about if that is a hack or not.