### PR TITLE
Load kernel modules

### DIFF
--- a/modules/usbip.nix
+++ b/modules/usbip.nix
@@ -78,5 +78,7 @@ in
 
       targets.multi-user.wants = map (busid: "usbip-auto-attach@${busid}.service") cfg.autoAttach;
     };
+
+    wsl.kernelModules = [ "vhci-hcd" ];
   };
 }

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -10,6 +10,14 @@ in
   options.wsl = with types; {
     enable = mkEnableOption "support for running NixOS as a WSL distribution";
     useWindowsDriver = mkEnableOption "OpenGL driver from the Windows host";
+    kernelModules = mkOption {
+      type = listOf str;
+      default = [ ];
+      description = ''
+        The set of kernel modules to be loaded in the second stage of
+        the boot process via systemd-modules-load.service.
+      '';
+    };
     binShPkg = mkOption {
       type = package;
       internal = true;
@@ -114,6 +122,9 @@ in
         })
         (mkIf config.wsl.wslConf.network.generateResolvConf {
           "resolv.conf".enable = false;
+        })
+        (mkIf (cfg.kernelModules != [ ]) {
+          "modules-load.d/nixos.conf".text = concatStringsSep "\n" cfg.kernelModules;
         })
       ];
     };


### PR DESCRIPTION
WSL now supports kernel modules and come with a bunch configured as `m` and can be loaded this way. For example `vhci-hcd` used by usbip has changed from `y` to `m` and hence need to be explicitly loaded.

https://github.com/dorssel/usbipd-win/issues/995
https://github.com/microsoft/WSL/discussions/11789#discussioncomment-10083621

Unfortunately we cannot use `boot.kernelModules` since it is gated behind `boot.kernel.enable`.