### PR TITLE
Add aarch64 NixOS flake output

### DIFF
--- a/docs/src/building.md
+++ b/docs/src/building.md
@@ -9,6 +9,12 @@ build your own tarball instead of relying on a prebuilt one:
 sudo nix run github:nix-community/NixOS-WSL#nixosConfigurations.default.config.system.build.tarballBuilder
 ```
 
+For Arm-based PCs, run:
+
+```sh
+sudo nix run github:nix-community/NixOS-WSL#nixosConfigurations.aarch64.config.system.build.tarballBuilder
+```
+
 Or, if you want to build with local changes, run inside your checkout:
 
 ```sh

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,14 @@
             ];
           };
 
+          aarch64 = nixpkgs.lib.nixosSystem {
+            system = "aarch64-linux";
+            modules = [
+              self.nixosModules.default
+              (config { })
+            ];
+          };
+
           modern = nixpkgs.lib.warn "nixosConfigurations.modern has been renamed to nixosConfigurations.default" default;
 
           legacy = nixpkgs.lib.nixosSystem {


### PR DESCRIPTION
This repo seems to work pretty great on my Windows Arm laptop. So thanks for that!

This adds an `aarch64` convenience to the `nixosConfigurations` flake outputs.

It would be cool to see aarch64 integrated into the GitHub build and release actions so people can just download a prebuilt image. [I had some luck getting it to work on the GitHub runner via binfmt](https://github.com/josh/NixOS-WSL-ARM/blob/8ebbcbebcf7d27c47e0399fa7d8e384b86791955/.github/workflows/nix.yml#L14-L33).