### PR TITLE
shim: make systemd log to kmsg

### DIFF
--- a/utils/src/shim.rs
+++ b/utils/src/shim.rs
@@ -115,6 +115,7 @@ fn real_main() -> anyhow::Result<()> {
     Err(
         Command::new("/nix/var/nix/profiles/system/systemd/lib/systemd/systemd")
             .arg0(env::args_os().next().expect("arg0 missing"))
+            .arg("--log-target=kmsg") // log to dmesg
             .args(env::args_os().skip(1))
             .exec()
             .into(),


### PR DESCRIPTION
This makes it so that the systemd logs will be availably by running `dmesg` in another distro or the system distro

Closes #529