### PR TITLE
Update Docker Desktop integration

### DIFF
--- a/modules/docker-desktop.nix
+++ b/modules/docker-desktop.nix
@@ -18,6 +18,9 @@ with builtins; with lib; {
       environment.systemPackages = with pkgs; [
         docker
         docker-compose
+        # Compose links to Docker Desktop by opening 'docker-desktop://' URLs
+        # through xdg-open.
+        xdg-utils
       ];
 
       wsl.extraBin = with pkgs; [

--- a/modules/docker-desktop.nix
+++ b/modules/docker-desktop.nix
@@ -34,18 +34,6 @@ with builtins; with lib; {
         { src = "${shadow}/bin/usermod"; }
       ];
 
-      systemd.services.docker-desktop-proxy = {
-        description = "Docker Desktop proxy";
-        script = ''
-          ${config.wsl.wslConf.automount.root}/wsl/docker-desktop/docker-desktop-user-distro proxy --docker-desktop-root ${config.wsl.wslConf.automount.root}/wsl/docker-desktop
-        '';
-        wantedBy = [ "multi-user.target" ];
-        serviceConfig = {
-          Restart = "on-failure";
-          RestartSec = "30s";
-        };
-      };
-
       users.groups.docker.members = [
         config.wsl.defaultUser
       ];

--- a/modules/docker-desktop.nix
+++ b/modules/docker-desktop.nix
@@ -16,8 +16,6 @@ with builtins; with lib; {
     mkIf (config.wsl.enable && cfg.enable) {
 
       environment.systemPackages = with pkgs; [
-        docker
-        docker-compose
         # Compose links to Docker Desktop by opening 'docker-desktop://' URLs
         # through xdg-open.
         xdg-utils

--- a/modules/docker-desktop.nix
+++ b/modules/docker-desktop.nix
@@ -20,6 +20,17 @@ with builtins; with lib; {
         docker-compose
       ];
 
+      wsl.extraBin = with pkgs; [
+        # Required unconditionally to check that the WSL environment is conformant.
+        { src = "${coreutils}/bin/cat"; }
+        { src = "${coreutils}/bin/whoami"; }
+        # Required to create the 'docker' group and add the WSL user to it.
+        # This group and its user membership are managed by NixOS below but we
+        # create those symlinks anyway for robustness.
+        { src = "${shadow}/bin/groupadd"; }
+        { src = "${shadow}/bin/usermod"; }
+      ];
+
       systemd.services.docker-desktop-proxy = {
         description = "Docker Desktop proxy";
         script = ''


### PR DESCRIPTION
Fixes #235

Tested extensively with [Docker Desktop 4.34](https://docs.docker.com/desktop/release-notes/) and NixOS 24.05.

Please consider each commit individually during the review. Each of them provides a justification about the changes being performed.