### PR TITLE
Remove mentions of nix-ld-rs

### DIFF
--- a/docs/src/how-to/vscode.md
+++ b/docs/src/how-to/vscode.md
@@ -18,14 +18,14 @@ environment.systemPackages = [
 [nix-ld](https://github.com/Mic92/nix-ld) is a program that provides `/lib64/ld-linux-x86-64.so.2`,
 allowing foreign binaries to run on NixOS.
 
-Running the VSCode server on NixOS-WSL requires using [nix-ld-rs](https://github.com/nix-community/nix-ld-rs), instead of the regular nix-ld.
+Running the VSCode server on NixOS-WSL requires using nix-ld 2.0 which is as of writing only on NixOS unstable or [nix-ld-rs](https://github.com/nix-community/nix-ld-rs) on NixOS 24.05.
 
 To set it up, add the following to your configuration:
 
 ```nix
 programs.nix-ld = {
     enable = true;
-    package = pkgs.nix-ld-rs;
+    package = pkgs.nix-ld-rs; # only for NixOS 24.05
 };
 ```
 


### PR DESCRIPTION
Mic rewrote nix-ld and integrated the fork into it and that is the current default implementation in nixos-unstable