### PR TITLE
shell-wrapper: wrap /bin/sh

### DIFF
--- a/modules/systemd/native/wrap-shell.nix
+++ b/modules/systemd/native/wrap-shell.nix
@@ -5,31 +5,39 @@ with lib;
 let
   cfg = config.wsl;
 
+  wrapShell = shellPath:
+    pkgs.stdenvNoCC.mkDerivation {
+      name = "wrapped-${last (splitString "/" (shellPath))}";
+      buildCommand = ''
+        mkdir -p $out
+        cp ${config.system.build.nativeUtils}/bin/shell-wrapper $out/wrapper
+        ln -s ${shellPath} $out/shell
+      '';
+    };
+
   users-groups-module = import "${modulesPath}/config/users-groups.nix" {
     inherit lib utils pkgs;
     config = recursiveUpdate config {
       users.users = mapAttrs
         (n: v: v // {
-          shell =
-            let
-              shellPath = utils.toShellPath v.shell;
-              wrapper = pkgs.stdenvNoCC.mkDerivation {
-                name = "wrapped-${last (splitString "/" (shellPath))}";
-                buildCommand = ''
-                  mkdir -p $out
-                  cp ${config.system.build.nativeUtils}/bin/shell-wrapper $out/wrapper
-                  ln -s ${shellPath} $out/shell
-                '';
-              };
-            in
-            wrapper.outPath + "/wrapper";
+          shell = (wrapShell (utils.toShellPath v.shell)).outPath + "/wrapper";
         })
         config.users.users;
     };
   };
 in
 {
+  options.wsl.wrapBinSh = mkOption {
+    type = types.bool;
+    default = true;
+    description = ''
+      Wrap /bin/sh with a script that sets the correct environment variables (like the user shells). Only takes effect when using native systemd
+    '';
+  };
+
   config = mkIf (cfg.enable && cfg.nativeSystemd) {
     system.activationScripts.users = users-groups-module.config.system.activationScripts.users;
+
+    wsl.binShExe = mkIf config.wsl.wrapBinSh ((wrapShell "${config.wsl.binShPkg}/bin/sh").outPath + "/wrapper");
   };
 }

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -15,6 +15,12 @@ in
       internal = true;
       description = "Package to be linked to /bin/sh. Mainly useful to be re-used by other modules like envfs.";
     };
+    binShExe = mkOption {
+      type = str;
+      internal = true;
+      description = "Path to the shell executable to be linked to /bin/sh";
+      default = "${config.wsl.binShPkg}/bin/sh";
+    };
     defaultUser = mkOption {
       type = str;
       default = "nixos";
@@ -212,7 +218,7 @@ in
       populateBin = true;
       extraBin = [
         { src = "/init"; name = "wslpath"; }
-        { src = "${cfg.binShPkg}/bin/sh"; name = "sh"; }
+        { src = "${cfg.binShExe}"; name = "sh"; }
         { src = "${pkgs.util-linux}/bin/mount"; }
       ];
     };


### PR DESCRIPTION
Fixes the environment not being available to commands where /bin/sh is called directly. This happens for example when trying to switch into a dev container in a VSCode attached to the WSL distro. Fixes #555