### PR TITLE
24.05-compat: sync with nixos-hardware

### DIFF
--- a/modules/24.05-compat.nix
+++ b/modules/24.05-compat.nix
@@ -5,5 +5,9 @@
   imports = lib.optionals (lib.versionOlder lib.version "24.11pre") [
     (lib.mkAliasOptionModule [ "hardware" "graphics" "enable" ] [ "hardware" "opengl" "enable" ])
     (lib.mkAliasOptionModule [ "hardware" "graphics" "extraPackages" ] [ "hardware" "opengl" "extraPackages" ])
+    (lib.mkAliasOptionModule [ "hardware" "graphics" "extraPackages32" ] [ "hardware" "opengl" "extraPackages32" ])
+    (lib.mkAliasOptionModule [ "hardware" "graphics" "enable32Bit" ] [ "hardware" "opengl" "driSupport32Bit" ])
+    (lib.mkAliasOptionModule [ "hardware" "graphics" "package" ] [ "hardware" "opengl" "package" ])
+    (lib.mkAliasOptionModule [ "hardware" "graphics" "package32" ] [ "hardware" "opengl" "package32" ])
   ];
 }


### PR DESCRIPTION
Fixes building on NixOS 24.05 (for me - [nixos-modules](https://github.com/NuschtOS/nixos-modules) uses some of these options and breaks if both of them exists but only partially)