### PR TITLE
Fix PowerShell syntax issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Modules for running NixOS on the Windows Subsystem for Linux
 3. Import the tarball into WSL:
 
 - ```powershell
-  wsl --import NixOS $env:USERPROFILE\NixOS\ nixos-wsl.tar.gz --version 2
+  wsl --import NixOS $env:USERPROFILE\NixOS nixos-wsl.tar.gz --version 2
   ```
 
 4. You can now run NixOS:

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -12,13 +12,13 @@ First, [download the latest release](https://github.com/nix-community/NixOS-WSL/
 Then open up a PowerShell and run:
 
 ```powershell
-wsl --import NixOS $env:USERPROFILE\NixOS\ nixos-wsl.tar.gz --version 2
+wsl --import NixOS $env:USERPROFILE\NixOS nixos-wsl.tar.gz --version 2
 ```
 
 Or for Command Prompt:
 
 ```cmd
-wsl --import NixOS %USERPROFILE%\NixOS\ nixos-wsl.tar.gz --version 2
+wsl --import NixOS %USERPROFILE%\NixOS nixos-wsl.tar.gz --version 2
 ```
 
 This sets up a new WSL distribution `NixOS` that is installed in a directory called `NixOS` inside your user directory.


### PR DESCRIPTION
If there is a leading backslash `wsl` will fail with help-text.

Fixes #606