### PR TITLE
wsl-conf: alter regex to stop tripping up on darwin

### DIFF
--- a/modules/wsl-conf.nix
+++ b/modules/wsl-conf.nix
@@ -42,7 +42,7 @@ with lib; {
               description = "Mount entries from /etc/fstab through WSL. You should probably leave this on false, because systemd will mount those for you.";
             };
             root = mkOption {
-              type = types.strMatching "^/(.*[^/]|)$";
+              type = types.strMatching "^/(.*[^/])?$";
               default = "/mnt";
               description = "The directory under which to mount windows drives.";
             };


### PR DESCRIPTION
With https://github.com/nix-community/NixOS-WSL/pull/636 the regex was altered, but the regex is illegal on darwin, beacuse of the empty regex. Ordinary `nix flake check` will trigger a failure see [my github actions run](https://github.com/isabelroses/dotfiles/actions/runs/13992975191/job/39180939977). Hopefully this fixes that. However, I have not tested it out on nixos wsl with a `/` only mount.