### PR TITLE
wsl-distro: drop user-runtime-dir hack

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -143,16 +143,6 @@ in
       };
     };
 
-    # Prevent systemd from mounting a tmpfs over the runtime dir (and thus hiding the wayland socket)
-    systemd.services."user-runtime-dir@" = {
-      overrideStrategy = "asDropin";
-      serviceConfig.ExecStart =
-        [
-          "" # unset old value
-          "${pkgs.coreutils}/bin/true"
-        ];
-    };
-
     # dhcp is handled by windows
     networking.dhcpcd.enable = false;
 


### PR DESCRIPTION
It isn't actually necessary, lingering is just completely broken with how current WSL handles runtime directories.