### PR TITLE
Fix aarch64-darwin evaluation compatibility

### DIFF
--- a/modules/wsl-conf.nix
+++ b/modules/wsl-conf.nix
@@ -42,7 +42,7 @@ with lib; {
               description = "Mount entries from /etc/fstab through WSL. You should probably leave this on false, because systemd will mount those for you.";
             };
             root = mkOption {
-              type = types.strMatching "^/(.*[^/]|)$";
+              type = types.strMatching "^/(.*[^/])?$";
               default = "/mnt";
               description = "The directory under which to mount windows drives.";
             };


### PR DESCRIPTION
Regex matching works slightly differently on aarch64-darwin systems than on others. See NixOS/nix#4758

<details>
<summary>aarch64-darwin results</summary>
<img width="371" alt="image" src="https://github.com/user-attachments/assets/caa6c8fd-e97f-4c7f-9f5d-7c2d5ddca71c" />
</details>

<details>
<summary>x86_64-linux results</summary>
<img width="340" alt="image" src="https://github.com/user-attachments/assets/4990636c-7975-4a93-909a-4cc8f5c5328c" />
</details>
