### PR TITLE
fix: usbip is missing cat and ls

### DIFF
--- a/modules/usbip.nix
+++ b/modules/usbip.nix
@@ -45,9 +45,9 @@ in
     services.udev.enable = true;
 
     wsl.extraBin = [
-      { src = lib.getExe pkgs.coreutils; }
-      { src = lib.getExe pkgs.coreutils; }
-      { src = lib.getExe pkgs.kmod; }
+      { src = "${pkgs.coreutils}/bin/cat"; }
+      { src = "${pkgs.coreutils}/bin/ls"; }
+      { src = "${pkgs.kmod}/bin/modprobe"; }
     ];
 
     systemd = {


### PR DESCRIPTION
Fixes #662 

Stacked on top of #666. That needs to be merged first