### PR TITLE
Fix usbip when enableStrictShellChecks is turned on

### DIFF
--- a/modules/usbip.nix
+++ b/modules/usbip.nix
@@ -65,6 +65,7 @@ in
           ip="${cfg.snippetIpAddress}"
 
           echo "Starting auto attach for busid $busid on $ip."
+          # shellcheck disable=SC1091
           source ${usbipd-win-auto-attach} "$ip" "$busid"
         '';
       };


### PR DESCRIPTION
```
unit-script-usbip-auto-attach_-start> building '/nix/store/dd4ssa8fni4gv3zg79p20pbi8d0k81s5-unit-script-usbip-auto-attach_-start.drv' unit-script-usbip-auto-attach_-start>
unit-script-usbip-auto-attach_-start> In /nix/store/fxkgxc0yzwcdqklcyd5y54gfi13n5ack-unit-script-usbip-auto-attach_-start/bin/usbip-auto-attach_-start line 10: unit-script-usbip-auto-attach_-start> source /nix/store/3l16mhbr2d8kyn7r3x6dr3qr4vz8pbdi-nll5ayjp1474ax1pyq3qf52arn438dn8-auto-attach.sh "$ip" "$busid"
unit-script-usbip-auto-attach_-start>        ^-- SC1091 (info): Not following: /nix/store/3l16mhbr2d8kyn7r3x6dr3qr4vz8pbdi-nll5ayjp1474ax1pyq3qf52arn438dn8-auto-attach.sh was not specified as input (see shellcheck -x).
unit-script-usbip-auto-attach_-start>
unit-script-usbip-auto-attach_-start> For more information:
unit-script-usbip-auto-attach_-start>   https://www.shellcheck.net/wiki/SC1091 -- Not following: /nix/store/3l16mhb...
```