### PR TITLE
Make .wsl file pass the validation script

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -49,6 +49,12 @@ jobs:
     needs:
       - build
 
+  validate:
+    name: Validate 🩺
+    uses: ./.github/workflows/run_validate.yml
+    needs:
+      - build
+
   docs:
     name: Docs 📕
     uses: ./.github/workflows/run_docs.yml
@@ -62,6 +68,7 @@ jobs:
       - build
       - checks
       - tests
+      - validate
       - docs
     steps:
       - uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
@@ -75,6 +82,7 @@ jobs:
             - 📋 Checks: ${{ needs.checks.result && '✅' || '❌' }}
             - 🛠️ Build: ${{ needs.build.result && '✅' || '❌' }}
             - 🧪 Tests: ${{ needs.tests.result && '✅' || '❌' }}
+            - 🩺 Validate: ${{ needs.validate.result && '✅' || '❌' }}
             - 📕 Docs: ${{ needs.docs.result && '✅' || '❌' }}
 
             [See the logs here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
@@ -86,6 +94,7 @@ jobs:
             "Checks" = "${{ needs.checks.result }}"
             "Build" = "${{ needs.build.result }}"
             "Tests" = "${{ needs.tests.result }}"
+            "Validate" = "${{ needs.validate.result }}"
             "Docs" = "${{ needs.docs.result }}"
           }
 

--- a/.github/workflows/run_validate.yml
+++ b/.github/workflows/run_validate.yml
@@ -1,0 +1,30 @@
+name: Validate Tarball
+
+on:
+  workflow_call: {}
+
+jobs:
+  validate:
+    name: Validate Tarball 🩺
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout WSL Repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: microsoft/WSL
+          ref: 2.6.0
+
+      - name: Install dependencies 📦
+        shell: bash
+        run: |
+          pip3 install -r distributions/requirements.txt
+
+      - name: Download Tarball 📥
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: tarball
+
+      - name: Validate Tarball 🩺
+        shell: bash
+        run: |
+          python3 distributions/validate-modern.py --tar nixos.wsl

--- a/modules/build-tarball.nix
+++ b/modules/build-tarball.nix
@@ -122,6 +122,7 @@ in
           --owner=0 \
           --group=0 \
           --numeric-owner \
+          --hard-dereference \
           . \
         | pigz > "$out"
       '';

--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -201,6 +201,7 @@ in
         { src = "/init"; name = "wslpath"; }
         { src = "${cfg.binShExe}"; name = "sh"; }
         { src = "${pkgs.util-linux}/bin/mount"; }
+        { src = "${pkgs.bashInteractive}/bin/bash"; }
       ];
     };
 


### PR DESCRIPTION
The WSL repo contains a script called `validate-modern.py` that can be used to verify if a distribution tarball complies with WSL's expectations. This adds a test for that to the CI and makes the produced tarballs compliant