### PR TITLE
fix: escape shell arguments in wsl-distro bin helpers

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -186,8 +186,8 @@ in
         ${concatStringsSep "\n" (map
           (entry:
             if entry.copy
-            then "cp -f ${entry.src} /bin/${entry.name}"
-            else "ln -sf ${entry.src} /bin/${entry.name}"
+            then "cp -f ${escapeShellArg entry.src} ${escapeShellArg "/bin/${entry.name}"}"
+            else "ln -sf ${escapeShellArg entry.src} ${escapeShellArg "/bin/${entry.name}"}"
           )
           config.wsl.extraBin
         )}
@@ -210,8 +210,8 @@ in
         (map
           (entry:
             if entry.copy
-            then "cp -f ${entry.src} $out/${entry.name}"
-            else "ln -sf ${entry.src} $out/${entry.name}"
+            then "cp -f ${escapeShellArg entry.src} $out/${escapeShellArg entry.name}"
+            else "ln -sf ${escapeShellArg entry.src} $out/${escapeShellArg entry.name}"
           )
           cfg.extraBin
         );


### PR DESCRIPTION
Currently my use case was to add Windows GPG to extraBin; however, the path is "/mnt/c/Program Files (x86)/GnuPG/bin/gpg.exe" which contains spaces and parentheses that need to be escaped.
Without any modification, the string goes as is in the init script, and the cp/ln commands are just broken.
I temporarily fixed it by escaping the chars in the nix string "/mnt/c/Program\\ Files\\ \\(x86\\)/GnuPG/bin/gpg.exe".
However, it would, I think, be way better to escape the params at the script generation.

Summarry : 

* Added `escapeShellArg` to both source and destination arguments in `cp` and `ln` commands for entries in `config.wsl.extraBin` and `cfg.extraBin`, ensuring safer shell command execution.