### PR TITLE
fix: remove NTP servers by default

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -219,6 +219,7 @@ in
     # WSL expects Chrony to be at /sbin/chrony and read /etc/chrony, ours does neither, so recreate the setup (mostly)
     # The really important bit is the refclock - otherwise the clock runs ahead randomly.
     # https://github.com/microsoft/WSL/blob/2eac1dafeca0d88320ff2260c5d5fe5dbb09cd33/src/linux/init/main.cpp#L3796
+    # By default we shouldn't use the NixOS NTP servers since the clock is set by WSL.
     services.chrony = {
       enable = true;
       extraConfig = ''
@@ -226,6 +227,7 @@ in
         leapsectz right/UTC
         refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
       '';
+      servers = mkDefault [ ];
     };
 
     warnings = flatten [


### PR DESCRIPTION
Fixes #854 

By default we only want to the "PHC0" provided via WSL, meaning we don't need to spend time reaching out to NTP servers, or conflicts that can happen with differing time.

In forked repository enabled the workflows. Passed builds, checks and tests. The exception was docs due to GitHub Pages being disabled by default.

```
[  OK  ] Tests
[  OK  ] Build
[  OK  ] Checks
[  OK  ] Validate
[ FAIL ] Docs
```