### PR TITLE
feat: add wsl2-ssh-agent integration

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -4,6 +4,7 @@
     ./docker-desktop.nix
     ./interop.nix
     ./recovery.nix
+    ./ssh-agent.nix
     ./systemd
     ./usbip.nix
     ./version.nix

--- a/modules/ssh-agent.nix
+++ b/modules/ssh-agent.nix
@@ -1,0 +1,51 @@
+{ config
+, lib
+, pkgs
+, ...
+}:
+
+let
+  cfg = config.wsl.ssh-agent;
+in
+{
+  options.wsl.ssh-agent = {
+    enable = lib.mkEnableOption "ssh-agent passthrough to Windows";
+
+    package = lib.mkPackageOption pkgs "wsl2-ssh-agent" { };
+
+    users = lib.mkOption {
+      type =
+        let
+          inherit (lib.types) either enum listOf;
+          userNames = lib.attrNames config.users.users;
+        in
+        either
+          (enum [
+            "!@system"
+            "@system"
+          ])
+          (listOf (enum userNames));
+      default = "!@system";
+      description = ''
+        Users to activate the service for. Defaults to all non-system users.
+      '';
+    };
+  };
+
+  config = lib.mkIf (config.wsl.enable && cfg.enable) {
+    systemd.user.services.wsl2-ssh-agent = {
+      description = "WSL2 SSH Agent Bridge";
+      after = [ "network.target" ];
+      wantedBy = [ "default.target" ];
+      unitConfig = {
+        ConditionUser = lib.join "|" (lib.toList cfg.users);
+      };
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/wsl2-ssh-agent --verbose --foreground --socket=%t/wsl2-ssh-agent.sock";
+        Restart = "on-failure";
+      };
+    };
+
+    environment.variables.SSH_AUTH_SOCK = "$XDG_RUNTIME_DIR/wsl2-ssh-agent.sock";
+  };
+}


### PR DESCRIPTION
Adds support for ssh-agent passthrough to the Windows host via [wsl2-ssh-agent](https://github.com/mame/wsl2-ssh-agent).

This was recently added to nixpkgs via https://github.com/NixOS/nixpkgs/pull/444409. The package is only available in unstable and the 25.11 beta so as heads up this will not build against 25.05 or earlier. Implementation mirrors the [systemd user service in the upstream](https://github.com/mame/wsl2-ssh-agent/blob/850ac8fbdea3ce1d8b0f7b221c904ffc14662815/extras/systemd/user/wsl2-ssh-agent.service). It seems to make more sense to include that here than the package itself as this is the only place it will be used.

This enables usage of on-disk keys without mapping these in, [TPM backed keys via Windows Hello](https://cedwards.xyz/tpm-backed-ssh-keys-on-windows-11/), or any other source already configured on the outer host.