### PR TITLE
fix: remove redundant `chronyd`

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -216,6 +216,9 @@ in
           cfg.extraBin
         );
 
+    # Disable `systemd-timesyncd` to prevent conflict with the `chronyd` in the WSL root namespace
+    services.timesyncd.enable = false;
+
     warnings = flatten [
       (optional (config.services.resolved.enable && config.wsl.wslConf.network.generateResolvConf)
         "systemd-resolved is enabled, but resolv.conf is managed by WSL (wsl.wslConf.network.generateResolvConf)"


### PR DESCRIPTION
Resolve #956

Remove the `services.chrony` section as `chronyd` is already running in the WSL2 root namespace.