### PR TITLE
feat: add home manager app directory as a potential app source

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -172,6 +172,10 @@ in
               targets+=("/etc/profiles/per-user/${config.users.users.${cfg.defaultUser}.name}/share/$x/.")
             fi
 
+            if [[ -d "/home/${config.users.users.${cfg.defaultUser}.name}/.nix-profile/share/$x" ]]; then
+               targets+=("/home/${config.users.users.${cfg.defaultUser}.name}/.nix-profile/share/$x/.")
+            fi
+
             if (( ''${#targets[@]} != 0 )); then
               mkdir -p "/usr/share/$x"
               ${pkgs.rsync}/bin/rsync --archive --copy-dirlinks --delete-after --recursive "''${targets[@]}" "/usr/share/$x"


### PR DESCRIPTION
Hello! 

This is a port of something I use in my own configuration. Currently, if I install some applications via standalone Home Manager (not nixos module), they are not getting populated into /usr/applications, and therefore are not accessible from Windows start menu.

This should fix that. I can also put it to a separate configuration option if it's required 😊