### PR TITLE
Add GitHub Actions workflow for fork sync builds

### DIFF
--- a/.github/workflows/on_fork_sync.yml
+++ b/.github/workflows/on_fork_sync.yml
@@ -1,0 +1,48 @@
+name: "Build on Fork Sync"
+
+# This workflow builds the .wsl tarball whenever you sync your fork with upstream.
+# The artifact will be available for download from the Actions tab.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {} # Allows manual triggering from the Actions tab
+
+jobs:
+  build:
+    name: Build WSL Tarball
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: ./.github/actions/install-nix
+
+      - name: Set Version
+        uses: ./.github/actions/version
+        id: version
+
+      - name: Build Tarball
+        uses: ./.github/actions/build-wsl-tarball
+        with:
+          config: default
+          filename: nixos.wsl
+
+      - name: Upload Tarball
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: nixos-wsl-${{ steps.version.outputs.version }}
+          path: nixos.wsl
+          retention-days: 90
+
+      - name: Build Summary
+        run: |
+          echo "## NixOS-WSL Build Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Download the \`nixos.wsl\` artifact from the Actions tab." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automatically builds the NixOS-WSL tarball whenever changes are pushed to the main branch or when manually triggered. This enables fork maintainers to easily generate updated WSL tarballs without running builds locally.

## Changes
- **New workflow file**: `.github/workflows/on_fork_sync.yml`
  - Triggers on pushes to `main` branch
  - Supports manual triggering via `workflow_dispatch`
  - Builds the WSL tarball using existing custom actions
  - Uploads the artifact with a 90-day retention policy
  - Generates a build summary in the GitHub Actions UI

## Implementation Details
- Uses existing reusable actions for Nix installation, version management, and tarball building
- Artifact is named with the version number for easy identification
- Build summary is posted to the workflow run for quick reference
- Artifact retention is set to 90 days to manage storage costs
- All action versions are pinned to specific commits for reproducibility

https://claude.ai/code/session_01V7QwFhHbuSW8dPwQ3MNoyn