### PR TITLE
test(options-doc): test doc generation for module

### DIFF
--- a/checks/options-doc.nix
+++ b/checks/options-doc.nix
@@ -1,0 +1,21 @@
+{ system
+, inputs
+, ...
+}:
+
+let
+  eval = inputs.nixpkgs.lib.nixosSystem {
+    inherit system;
+    modules = [
+      inputs.self.nixosModules.wsl
+      {
+        # This forces evaluation of all types/descriptions in all modules
+        documentation.nixos.includeAllModules = true;
+      }
+    ];
+  };
+in
+# Return the options JSON derivation.
+  # If any option type has a circular reference or missing attribute,
+  # evaluation will fail here.
+eval.config.system.build.manual.optionsJSON

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,7 @@
         {
           nixpkgs-fmt = pkgs.callPackage ./checks/nixpkgs-fmt.nix args;
           nixpkgs-input = pkgs.callPackage ./checks/nixpkgs-input.nix args;
+          options-doc = pkgs.callPackage ./checks/options-doc.nix args;
           rustfmt = pkgs.callPackage ./checks/rustfmt.nix args;
           side-effects = pkgs.callPackage ./checks/side-effects.nix args;
           username = pkgs.callPackage ./checks/username.nix args;


### PR DESCRIPTION
## Summary
Add a regression test to the CI suite that validates the evaluation of all NixOS module options.

## Problem
A recent bug demonstrated that using `config` values inside an option's `type` definition (e.g., `lib.attrNames config.users.users`) causes documentation generation to fail with "missing attribute" or "infinite recursion" errors. These errors are often only discovered late in the development cycle or when building the project's documentation.

## Solution
This PR introduces a new flake check, `options-doc`, which:
1. Instantiates a minimal NixOS system using the WSL module.
2. Enables `documentation.nixos.includeAllModules = true`.
3. Attempts to build the `options.json` derivation.

By enabling `includeAllModules`, Nix is forced to deeply evaluate the `type` and `description` fields of every option in every module. If an option type contains a circular reference or relies on a `config` value that isn't available during doc-gen, this check will fail in CI.

## Changes
- Created `checks/options-doc.nix`: Logic to evaluate the system manual's options.
- Updated `flake.nix`: Integrated the new check into the `checks` attribute set.

## Verification
You can run this check locally with:
```bash
nix build .#checks.<system>.options-doc
```

---
<details> Output:

```shell
 nix build .\#checks.x86_64-linux.options-doc
warning: Git tree '/home/sedlund/dev/sedlund/NixOS-WSL' is dirty
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'options.json'
         whose name attribute is located at /nix/store/8rqf4w66r61rp58ffqnpjni2zlg4cyhs-source/pkgs/stdenv/generic/make-derivation.nix:536:13

       … while evaluating attribute 'options' of derivation 'options.json'
         at /nix/store/8rqf4w66r61rp58ffqnpjni2zlg4cyhs-source/nixos/lib/make-options-doc/default.nix:218:9:
          217|         passAsFile = [ "options" ];
          218|         options = builtins.unsafeDiscardStringContext (builtins.toJSON optionsNix);
             |         ^
          219|         # merge with an empty set if baseOptionsJSON is null to run markdown

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'users' missing
       at /nix/store/wxrjb89gq31c306qybgb2zyhrcm6k3wi-source/modules/ssh-agent.nix:20:37:
           19|           inherit (lib.types) either enum listOf;
           20|           userNames = lib.attrNames config.users.users;
             |                                     ^
           21|         in

```

</details>