### PR TITLE
fix: proper check for setting /sbin when changing populateBin from true to false

### DIFF
--- a/modules/systemd/native/default.nix
+++ b/modules/systemd/native/default.nix
@@ -45,7 +45,7 @@ with lib; {
           ''
           else ''
             echo "setting up /sbin..."
-            if [ ! -d /sbin ]; then
+            if [ ! -d /sbin ] || [ -L /sbin ]; then
               rm -rf /sbin
               mkdir -p /sbin
             fi

--- a/tests/envfs/envfs.Tests.ps1
+++ b/tests/envfs/envfs.Tests.ps1
@@ -1,0 +1,37 @@
+BeforeAll {
+  . $PSScriptRoot/../lib/lib.ps1
+}
+
+Describe "envfs" {
+  BeforeAll {
+    $distro = [Distro]::new()
+  }
+
+  It "should install" {
+    $distro.InstallConfig("$PSScriptRoot/envfs.nix", "switch")
+  }
+
+  It "should not break the distro" {
+    $distro.Launch("true")
+    $LASTEXITCODE | Should -Be 0
+  }
+
+  It "should allow running scripts with #!/bin/python3 instead of #!/usr/bin/env python3" {
+    $distro.Launch("echo '#!/bin/python3' > ~/test.py")
+    $LASTEXITCODE | Should -Be 0
+
+    $distro.Launch("echo print(`"hello`") >> ~/test.py")
+    $LASTEXITCODE | Should -Be 0
+
+    $distro.Launch("chmod +x ~/test.py")
+    $LASTEXITCODE | Should -Be 0
+
+    $output = $distro.Launch("~/test.py") | Select-Object -Last 1
+    $output | Should -BeExactly "hello"
+    $LASTEXITCODE | Should -Be 0
+  }
+
+  AfterAll {
+    $distro.Uninstall()
+  }
+}

--- a/tests/envfs/envfs.nix
+++ b/tests/envfs/envfs.nix
@@ -1,0 +1,15 @@
+{ lib, pkgs, ... }:
+with lib; {
+  imports = [
+    <nixos-wsl/modules>
+  ];
+
+  config = {
+    wsl.enable = true;
+    services.envfs.enable = true;
+
+    environment.systemPackages = [
+      pkgs.python3
+    ];
+  };
+}


### PR DESCRIPTION
fix #1009 

The bug 👿 introduced by https://github.com/nix-community/NixOS-WSL/pull/666/changes  

If populateBin is false (i.e. when services.envfs enabled for nixos) the check verifies if the `/sbin` is not folder, but if the system was built before without envfs the `/sbin` will be populated as symlink to `/bin`. 

After enabling envfs the check will fail because the symlink to dir is also a dir, so the sbin was always pointing to the empty bin managed by envfs. 

The fix verifies that the `/sbin` is recreated if it's a symlink or not directory. 

Verified on both latest bare nixos-wsl distro and my local setup that was previously bricking after every attempt to enable envfs.