### PR TITLE
systemd: use mkDefault for oomd.enable to allow downstream override

### DIFF
--- a/modules/systemd/default.nix
+++ b/modules/systemd/default.nix
@@ -12,8 +12,10 @@
     services.udev.enable = lib.mkDefault false;
 
     systemd = {
-      # systemd-oomd requires cgroup pressure info which WSL doesn't have
-      oomd.enable = false;
+      # systemd-oomd requires cgroup pressure info (PSI). Older WSL2 kernels
+      # lacked CONFIG_PSI, but modern kernels (6.1+) support it. Use mkDefault
+      # so downstream consumers on newer kernels can re-enable oomd.
+      oomd.enable = lib.mkDefault false;
       # Disable systemd units that don't make sense on WSL
       services.firewall.enable = false;
 

--- a/modules/systemd/default.nix
+++ b/modules/systemd/default.nix
@@ -13,8 +13,7 @@
 
     systemd = {
       # systemd-oomd requires cgroup pressure info (PSI). Older WSL2 kernels
-      # lacked CONFIG_PSI, but modern kernels (6.1+) support it. Use mkDefault
-      # so downstream consumers on newer kernels can re-enable oomd.
+      # lacked CONFIG_PSI, but modern kernels (6.1+) support it.
       oomd.enable = lib.mkDefault false;
       # Disable systemd units that don't make sense on WSL
       services.firewall.enable = false;


### PR DESCRIPTION
## Summary
- Change bare `false` to `lib.mkDefault false` for `systemd.oomd.enable`
- Modern WSL2 kernels (6.1+) support PSI (`/proc/pressure/*`), making systemd-oomd functional
- Default behavior unchanged — oomd remains disabled unless downstream explicitly enables it

## Motivation
Downstream NixOS-WSL consumers using cgroup-based memory limits (e.g., for nix evaluation guards) need systemd-oomd for `ManagedOOMMemoryPressure=kill` on custom slices. Currently this requires `mkForce` to override the bare `false`, which is unnecessarily heavy.

## Testing
Verified on WSL2 kernel 6.6.87.2-microsoft-standard-WSL2:
- `/proc/pressure/memory` returns valid PSI data
- `systemd-oomd.service` starts and runs correctly after override
- `ManagedOOMMemoryPressure=kill` on custom slices works as expected