### PR TITLE
docs(nix-flakes): say where the configuration file is

### DIFF
--- a/docs/src/how-to/nix-flakes.md
+++ b/docs/src/how-to/nix-flakes.md
@@ -1,6 +1,6 @@
 # How to configure NixOS-WSL with flakes
 
-First add a `nixos-wsl` input, then add `nixos-wsl.nixosModules.default` to your nixos configuration.
+First add a `nixos-wsl` input, then add `nixos-wsl.nixosModules.default` to your nixos configuration in `/etc/nixos/configuration.nix`.
 
 Below is a minimal `flake.nix` for you to get started:
 


### PR DESCRIPTION
Specify the configuration file location for nixos-wsl. That's useful for complete novices which just get started, and maybe don't yet know where proper places to read about configuration located.

Other alternative is to provide link to official NixOS docs which explain how to edit configuration. But I didn't yet found this location