### PR TITLE
fix: do not enable resolvconf if generateResolvConf is set to false

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -147,7 +147,7 @@ in
     networking.dhcpcd.enable = false;
 
     # disable resolvconf if WSL is managing it
-    networking.resolvconf.enable = !config.wsl.wslConf.network.generateResolvConf;
+    networking.resolvconf.enable = mkIf config.wsl.wslConf.network.generateResolvConf false;
 
     users.users.${cfg.defaultUser} = {
       isNormalUser = true;


### PR DESCRIPTION
#1044 disables resolvconf if managed by WSL:
```nix
networking.resolvconf.enable = !config.wsl.wslConf.network.generateResolvConf;
```

But this also causes resolvconf to be enabled if generateResolvConf is disabled, which this PR fixes.

Resolves #1045 