### PR TITLE
ci: limit renovate to supported branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,7 @@
     ":semanticCommitTypeAll(chore)",
     "helpers:pinGitHubActionDigests",
   ],
-  baseBranchPatterns: ["main", "/^release-.+$/", "renovate-test"],
+  baseBranchPatterns: ["main", "release-25.11", "release-26.05"],
   labels: ["release-exclude", "renovate"],
   reviewers: ["nzbr"],
   nix: {


### PR DESCRIPTION
Also remove nonexistent renovate-test branch from config.
