### PR TITLE
modules/wsl-distro: don't disable bootspec

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -113,7 +113,6 @@ in
   config = mkIf cfg.enable {
     # WSL uses its own kernel and boot loader
     boot = {
-      bootspec.enable = false;
       initrd.enable = false;
       kernel.enable = false;
       loader.grub.enable = false;


### PR DESCRIPTION
Breaks on latest nixpkgs, nixpkgs side fix to get kernels back out of the closure: https://github.com/NixOS/nixpkgs/pull/530717