### PR TITLE
feat(wsl-conf): add boot.initTimeout option

### DIFF
--- a/modules/wsl-conf.nix
+++ b/modules/wsl-conf.nix
@@ -63,6 +63,16 @@ with lib; {
               default = true;
               description = "Use systemd as init. Disabling this may break your NixOS installation";
             };
+            initTimeout = mkOption {
+              type = types.nullOr types.ints.unsigned;
+              default = null;
+              description = ''
+                Time in milliseconds that WSL waits for the init process to become
+                ready when starting the distribution, and for `systemctl poweroff` to
+                finish when the distribution is terminated. When `null`, WSL's built-in
+                default of 10000 is used.
+              '';
+            };
           };
           interop = {
             enabled = mkOption {
@@ -108,7 +118,7 @@ with lib; {
   config = mkIf config.wsl.enable {
 
     environment.etc."wsl.conf".text = generators.toINI { } (
-      lib.filterAttrsRecursive (_: v: v != "") config.wsl.wslConf
+      lib.filterAttrsRecursive (_: v: v != null && v != "") config.wsl.wslConf
     );
 
     warnings = optional (!config.wsl.wslConf.boot.systemd)


### PR DESCRIPTION
Adds a `wsl.wslConf.boot.initTimeout` option, mapping to the `[boot] initTimeout` key in `wsl.conf`.

WSL parses this key in `src/linux/init/WslDistributionConfig.cpp` (`ConfigKey("boot.initTimeout", BootInitTimeout)`, default `10 * 1000` ms), but is undocumented.

It bounds how long WSL waits for init to become ready at boot and, since microsoft/WSL#13552, how long `systemctl poweroff` is given to run the shutdown sequence before WSL forces `reboot(RB_POWER_OFF)` (see also microsoft/WSL#13493).

Raising it lets services with longer `ExecStop` handlers shut down cleanly.