### PR TITLE
docs: clarify flakes how-to on flake.nix vs configuration.nix

### DIFF
--- a/docs/src/how-to/nix-flakes.md
+++ b/docs/src/how-to/nix-flakes.md
@@ -1,6 +1,17 @@
 # How to configure NixOS-WSL with flakes
 
-First add a `nixos-wsl` input, then add `nixos-wsl.nixosModules.default` to your nixos configuration in `/etc/nixos/configuration.nix`.
+[Flakes](https://wiki.nixos.org/wiki/Flakes) are an alternative, optional way
+to manage your NixOS configuration. They aren't required to use NixOS-WSL, but
+if you're already familiar with them, or want to use flake-only tooling, they
+work fine here too. If you're new to NixOS, it's fine to skip this page and
+stick with the plain `configuration.nix` setup from the rest of the docs.
+
+To switch to a flake-based configuration, create a new `/etc/nixos/flake.nix`
+(don't add this to `/etc/nixos/configuration.nix` — that will error, since
+`configuration.nix` is plain NixOS module syntax, not a flake). Your existing
+`configuration.nix` doesn't need to be rewritten: the flake below imports it
+as a module alongside `nixos-wsl.nixosModules.default`, so it keeps working
+as-is.
 
 Below is a minimal `flake.nix` for you to get started:
 
@@ -17,8 +28,8 @@ Below is a minimal `flake.nix` for you to get started:
         system = "x86_64-linux";
         modules = [
           nixos-wsl.nixosModules.default
+          ./configuration.nix
           {
-            system.stateVersion = "25.05";
             wsl.enable = true;
           }
         ];
@@ -27,3 +38,9 @@ Below is a minimal `flake.nix` for you to get started:
   };
 }
 ```
+
+`./configuration.nix` is your existing configuration — keep editing it as
+before, it's still plain NixOS module syntax. `flake.nix` just wraps it and
+adds `nixos-wsl.nixosModules.default` and `wsl.enable = true`, which is what
+actually enables NixOS-WSL. If `configuration.nix` already sets
+`system.stateVersion`, you don't need to set it again here.


### PR DESCRIPTION
## What

Clarifies `docs/src/how-to/nix-flakes.md`: flakes are optional, `flake.nix` is a new/separate file (not something to paste into `configuration.nix`), and updates the example flake to actually import the existing `./configuration.nix` as a module instead of duplicating its settings inline.

## Why

As reported in #604, a newcomer following this page pasted the `flake.nix` snippet into `/etc/nixos/configuration.nix` (which errors) because it wasn't clear the two were separate files, or how they relate. You mentioned the page is "admittedly very bare-bones" and welcomed a PR. The old example also didn't actually reference `./configuration.nix` despite the intro text saying to add the module "to your nixos configuration in `/etc/nixos/configuration.nix`", so even a careful reader couldn't see how the pieces fit together. Now the example shows `configuration.nix` being imported directly, matching how most people actually adopt flakes on an existing install.

## How this was tested

Docs-only Markdown change; I don't have `nix` available in my sandbox to build `.#docs` locally, so I read the rendered structure by eye (headings, code fence, links). Happy for CI's doc build to confirm.

Closes #604

---

**AI disclosure:** This PR (diff, commit message, and this description) was authored by an AI coding agent (Claude). I found no CONTRIBUTING.md or AI-usage policy in this repo to check against.
