### PR TITLE
Add /bin/true

### DIFF
--- a/modules/wsl-distro.nix
+++ b/modules/wsl-distro.nix
@@ -33,7 +33,7 @@ let
     assert cfg.useWindowsDriver;
     pkgs.runCommand "wsl-lib" { } ''
       mkdir -p "$out/lib"
-      
+
       ${concatMapStrings (path: ''
         ln -s ${escapeShellArg path} "$out/lib"
       '') (defaultLinks ++ extraLinks)}
@@ -232,6 +232,7 @@ in
         { src = "${cfg.binShExe}"; name = "sh"; }
         { src = "${pkgs.util-linux}/bin/mount"; }
         { src = "${pkgs.bashInteractive}/bin/bash"; }
+        { src = "${pkgs.coreutils}/bin/true"; }
       ];
     };
 


### PR DESCRIPTION
Adds `true` to `/bin` that is required by WSL since https://github.com/microsoft/WSL/commit/5a182d8ad30fff779ac40c223a7f061b9a3e8112